### PR TITLE
ci: scope PR/push triggers to master to avoid duplicate runs

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,8 +1,10 @@
 name: demo-checks
 
 on:
-  push:
   pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
 
 jobs:
   demo-e2e:


### PR DESCRIPTION
Limit demo-checks to:
- pull_request on master
- push on master

Prevents duplicate CI runs for PR branches (push+PR). Windows smoke already updated similarly.