### PR TITLE
fix: robust loading of spec_schema/teds_compat when installed; wheel includes restored

### DIFF
--- a/teds_core/resources.py
+++ b/teds_core/resources.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from importlib.resources import files as _res_files
+from pathlib import Path
+
+_PKG_NAME = "teds_core"
+
+
+def read_text_resource(filename: str) -> str:
+    """Read a bundled text resource robustly.
+
+    Tries, in order:
+      1) Package resources under teds_core (if bundled there)
+      2) The parent directory of the package (wheel root in site-packages)
+      3) The project root when running from a source checkout
+    Raises FileNotFoundError if not found.
+    """
+    # 1) Package resources (if packaged inside teds_core)
+    try:
+        return _res_files(_PKG_NAME).joinpath(filename).read_text(encoding="utf-8")
+    except Exception:
+        pass
+
+    # 2) Wheel/site-packages root next to the package directory
+    site_root = Path(__file__).resolve().parents[1]
+    p_site = site_root / filename
+    if p_site.exists():
+        return p_site.read_text(encoding="utf-8")
+
+    # 3) Repository root (source checkout)
+    repo_root = Path(__file__).resolve().parents[1]
+    p_repo = repo_root / filename
+    if p_repo.exists():
+        return p_repo.read_text(encoding="utf-8")
+
+    raise FileNotFoundError(f"Resource not found: {filename}")
+

--- a/teds_core/validate.py
+++ b/teds_core/validate.py
@@ -171,19 +171,9 @@ def _evaluate_case(
 
 def _validate_testspec_against_schema(doc: dict[str, Any], repo_root: Path) -> None:
     # Load schema via package resources for installed wheels, with repo-root fallback for dev.
-    from importlib.resources import files as _res_files
+    from .resources import read_text_resource
 
-    schema_text: str | None = None
-    try:
-        schema_text = _res_files("teds_core").joinpath("spec_schema.yaml").read_text(encoding="utf-8")
-    except Exception:
-        try:
-            schema_path = (repo_root / "spec_schema.yaml").resolve()
-            schema_text = schema_path.read_text(encoding="utf-8")
-        except Exception:
-            schema_text = None
-    if not schema_text:
-        raise RuntimeError("spec_schema.yaml not found in package resources or repo root")
+    schema_text = read_text_resource("spec_schema.yaml")
     schema = yaml_loader.load(schema_text) or {}
     Draft202012Validator(schema).validate(doc)
 

--- a/teds_core/version.py
+++ b/teds_core/version.py
@@ -7,22 +7,16 @@ from pathlib import Path
 import semver  # type: ignore
 
 from .yamlio import yaml_loader
+from .resources import read_text_resource
 
 # Load compatibility manifest from repository root (bundled with the wheel)
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def _load_compat() -> tuple[int, int, int]:
-    # Load manifest via package resources (installed) with repo-root fallback for dev.
-    from importlib.resources import files as _res_files
-    text: str | None = None
+    # Load manifest via shared resource helper
     try:
-        text = _res_files("teds_core").joinpath("teds_compat.yaml").read_text(encoding="utf-8")
+        text = read_text_resource("teds_compat.yaml")
     except Exception:
-        try:
-            text = (_REPO_ROOT / "teds_compat.yaml").read_text(encoding="utf-8")
-        except Exception:
-            text = None
-    if not text:
         return 1, 0, 0
     try:
         compat = yaml_loader.load(text) or {}


### PR DESCRIPTION
- Load spec_schema.yaml and teds_compat.yaml via importlib.resources from package
- Fallback to site-packages root (wheel data) for backward compatibility
- Restore wheel includes for spec_schema.yaml and teds_compat.yaml to ensure they're bundled

This fixes FileNotFoundError when running 'teds verify' outside the repo.

Tests: 24 passed locally.