### PR TITLE
ci(release): fix pre-publish smoke path handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
           . .pkg-smoke/bin/activate
           python -m pip install -U pip
           pip install dist/*.whl
+          REPO="${GITHUB_WORKSPACE}"
           run_dir=$(mktemp -d)
           cd "$run_dir"
           teds --version | sed -n '1p'
@@ -71,7 +72,6 @@ jobs:
           print('resource load OK')
           PY
           set +e
-          REPO="$PWD"
           teds verify "$REPO/demo/sample_tests.yaml" --output-level warning > /tmp/out.yaml
           rc=$?
           set -e


### PR DESCRIPTION
- Set REPO to GITHUB_WORKSPACE before cd into temp dir
- Ensures demo paths resolve correctly in tag builds
- Prevents false negative on verify step