### PR TITLE
docs: add v0.2.5 to CHANGELOG; adopt tests-first policy in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,9 @@
 - Golden tests: see `tests/cases/*` — case directories are behavior-focused (e.g., `format_divergence`, `output_filtering_and_inplace`). Each case has `schema.yaml`, `spec.yaml`, and `expected*.yaml`; tests compare parsed YAML structures and verify exit codes.
 - Demos remain under `demo/` for illustrative data and manual runs.
 - Test style: small, focused tests; tmp paths for I/O; import helpers directly (`validate_doc`, `validate_file`, `generate_from`).
+- Tests-first principle:
+  - For bug fixes and new features, write a failing test first that exposes the behavior, confirm it fails, then implement the fix/feature until the test passes.
+  - Do not rewrite history to reorder fix/test after the fact; keep the timeline truthful for easier analysis.
 
 ## Developer Hygiene (Agents)
 - Do not create temporary files or directories in the project root during manual reproduction or debugging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable user-facing changes for released versions.
 
+## 0.2.5 — 2025-09-09
+
+- fix(generate): resolve schema refs using absolute file paths when planning output mappings to avoid double-joining `base_dir` (e.g., running from a parent directory). Adds a regression test for relative schema paths in subdirectories.
+
+## 0.2.4 — 2025-09-09
+
+- docs: extract “Why this matters” details into a separate page and link from README.
+- ci/ruleset: require package-smoke in default branch ruleset; add package-smoke gating.
+
 ## 0.1.23
 
 - Validation: output always includes a complete testspec with a top-level `version` matching the supported testspec version.
@@ -21,4 +30,3 @@ All notable user-facing changes for released versions.
 - Initial public release.
 - CLI: `teds verify` to validate testspecs; `teds generate` to scaffold tests from schema refs.
 - Tests: output filtering (`--output-level`), in-place updates (`-i`), and exit codes aligned with validation results.
-


### PR DESCRIPTION
- CHANGELOG: add 0.2.5 entry (generate fix + regression test) and 0.2.4 summary
- AGENTS.md: codify tests-first principle (write failing test before fix/feature); do not rewrite history afterwards

Note: Going forward, include Release Notes at tagging time.