### PR TITLE
docs: clarify template variables limitations and pointer sanitization

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -578,8 +578,8 @@ tests:
 Control where generated test files are created using template variables:
 
 ```bash
-# Available template variables
-teds generate schema.yaml --target-template "{base}.{pointer}.custom.yaml"
+# Available template variables (JSON Pointer only - not JSON Path)
+teds generate schema.yaml#/components/schemas --target-template "{base}.{pointer}.custom.yaml"
 
 # Variables:
 # {file}     - schema.yaml
@@ -589,6 +589,26 @@ teds generate schema.yaml --target-template "{base}.{pointer}.custom.yaml"
 # {pointer}  - components+schemas (sanitized)
 # {index}    - 1, 2, 3... (for multiple targets)
 ```
+
+**Important**: Template variables only work with JSON Pointer syntax (`#/path`), not with JSON Path (`--json-path`).
+
+#### Pointer Sanitization with Plus Signs
+
+The `{pointer}` variable automatically converts JSON Pointer slashes to plus signs for safe filenames:
+
+```bash
+# JSON Pointer: #/components/schemas/User
+# Sanitized:    components+schemas+User
+teds generate api.yaml#/components/schemas/User
+# Creates: api.components+schemas+User.tests.yaml
+
+# JSON Pointer: #/$defs/Address
+# Sanitized:    $defs+Address
+teds generate schema.yaml#/$defs/Address
+# Creates: schema.$defs+Address.tests.yaml
+```
+
+**Why sanitization?** Slashes (`/`) are directory separators in file systems, so `components/schemas/User` would create subdirectories. The plus sign (`+`) replacement ensures the entire pointer becomes part of the filename, keeping all generated files in the same directory while preserving the hierarchical information from the JSON Pointer.
 
 ### Configuration Files for Complex Generation
 


### PR DESCRIPTION
## Summary
This hotfix addresses important gaps in the template variables documentation by clarifying:

### Key Clarifications Added
- **Scope limitation**: Template variables only work with JSON Pointer syntax (`#/path`), not JSON Path (`--json-path`)
- **Pointer sanitization explanation**: Detailed explanation of why and how plus signs replace slashes
- **Practical examples**: Clear before/after examples showing the conversion process

### Why This Matters
- **Prevents confusion**: Users won't try to use template variables with JSON Path
- **Explains naming**: Users understand why generated files have plus signs in names
- **Technical clarity**: Explains filesystem safety reason for sanitization

### Examples Added
```bash
# JSON Pointer: #/components/schemas/User
# Sanitized:    components+schemas+User
# Result:       api.components+schemas+User.tests.yaml
```

## Test plan
- [x] All examples use correct JSON Pointer syntax
- [x] Sanitization explanation is technically accurate
- [x] Clear distinction between JSON Pointer and JSON Path capabilities

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>