### PR TITLE
Fix README tutorial link with absolute GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Reports show complete test results with clean YAML formatting and clear message 
 
 ## Tutorial
 
-For a comprehensive step-by-step guide, see the [complete tutorial](docs/tutorial.md).
+For a comprehensive step-by-step guide, see the [complete tutorial](https://github.com/yaccob/teds/blob/master/docs/tutorial.md).
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Replace relative link with absolute GitHub URL for tutorial
- Ensures compatibility across GitHub repository view and PyPI package page
- Tested link functionality on GitHub - works correctly

## Changes
- Changed `docs/tutorial.md` to `https://github.com/yaccob/teds/blob/master/docs/tutorial.md`

## Benefits
- ✅ Works on GitHub repository view  
- ✅ Works on PyPI package documentation (PyPI uses same markdown renderer as GitHub)
- ✅ Direct link to master branch tutorial ensures always current content
- ✅ No broken links when viewed from external sources

## Testing
- [x] Link tested on GitHub - loads tutorial correctly
- [x] PyPI markdown support verified (uses cmarkgfm, same as GitHub)
- [x] Absolute GitHub URLs confirmed to work on PyPI

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)