### PR TITLE
docs: add GitHub Pages index with auto-redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="0; url=tutorial-with-fixed-toc.html">
+    <title>TeDS Documentation</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            text-align: center;
+            padding: 50px;
+            background: #f8f9fa;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background: white;
+            padding: 40px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            margin-bottom: 20px;
+        }
+        p {
+            color: #666;
+            line-height: 1.6;
+        }
+        .link {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 12px 24px;
+            background: #007bff;
+            color: white;
+            text-decoration: none;
+            border-radius: 6px;
+            transition: background 0.2s;
+        }
+        .link:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 TeDS Documentation</h1>
+        <p>You are being redirected to the TeDS Tutorial with fixed sidebar TOC...</p>
+        <p>If you are not redirected automatically, click the link below:</p>
+        <a href="tutorial-with-fixed-toc.html" class="link">📖 Open TeDS Tutorial</a>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #eee;">
+
+        <h3>📚 Available Documentation</h3>
+        <p style="margin-bottom: 10px;">
+            <a href="tutorial-with-fixed-toc.html">📖 Tutorial (Fixed TOC)</a> -
+            <em>Recommended: Modern layout with fixed sidebar navigation</em>
+        </p>
+        <p style="margin-bottom: 10px;">
+            <a href="tutorial.html">📄 Tutorial (Standard)</a> -
+            <em>Standard AsciiDoctor output</em>
+        </p>
+        <p style="margin-bottom: 10px;">
+            <a href="tutorial.md">📝 Tutorial (Markdown)</a> -
+            <em>Original markdown version</em>
+        </p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add index.html for GitHub Pages that automatically redirects to the tutorial with fixed TOC.

## Changes

- Create docs/index.html with automatic redirect to tutorial-with-fixed-toc.html
- Provide fallback navigation for all available documentation formats
- Enable direct access to TeDS tutorial via GitHub Pages root URL

## Benefits

- Users can access the tutorial directly via https://yaccob.github.io/teds/
- Automatic redirect to the best version (fixed TOC)
- Fallback options for different formats

## Test plan

- [x] index.html created with proper redirect
- [x] Fallback links for all documentation formats
- [x] Auto-redirect works correctly