### PR TITLE
Update README tutorial link to GitHub Pages HTML rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Reports show complete test results with clean YAML formatting and clear message 
 
 ## Tutorial
 
-For a comprehensive step-by-step guide, see the [complete tutorial](https://github.com/yaccob/teds/blob/master/docs/tutorial.html).
+For a comprehensive step-by-step guide, see the [complete tutorial](https://yaccob.github.io/teds/tutorial.html).
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Change tutorial link from blob view to GitHub Pages
- Link directly to rendered tutorial.html instead of raw source
- Provides better user experience with proper HTML rendering

## Test plan
- [x] Update README.md tutorial link
- [x] Verify link points to GitHub Pages URL for proper HTML rendering
- [x] Commit changes with proper message format

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)