### PR TITLE
Fix JSON Path documentation in tutorial

### DIFF
--- a/docs/tutorial.adoc
+++ b/docs/tutorial.adoc
@@ -208,24 +208,73 @@ teds generate sample_schemas.yaml#/components/schemas/Email
 
 ==== JSON Path (Alternative Method)
 
-**JSON Path** uses CSS-like selector syntax and requires **explicit wildcards** to select multiple elements:
+**JSON Path** uses CSS-like selector syntax and requires **explicit wildcards** to select multiple elements. TeDS supports JSON Path through YAML/JSON configuration objects in three ways:
+
+===== Method 1: Configuration Files
 
 [source,bash]
 ----
-# Select ALL schemas under components/schemas (equivalent to JSON Pointer above)
-teds generate sample_schemas.yaml --json-path '$.components.schemas.*'
+# Create a configuration file
+cat > config.yaml << EOF
+sample_schemas.yaml:
+  paths: ["$.components.schemas.*"]
+EOF
 
-# Select specific schemas by name pattern
-teds generate sample_schemas.yaml --json-path '$.components.schemas[User,Email,Product]'
+# Generate using @file syntax
+teds generate @config.yaml
+----
 
-# Select schemas at any level that match a pattern
-teds generate sample_schemas.yaml --json-path '$..schemas[?(@.type=="object")]'
+===== Method 2: Direct YAML/JSON Arguments
+
+[source,bash]
+----
+# Pass configuration directly as YAML/JSON string
+teds generate '{"sample_schemas.yaml": {"paths": ["$.components.schemas.*"]}}'
+
+# Multiple paths in one schema
+teds generate '{"api.yaml": {"paths": ["$.components.schemas.User", "$.components.schemas.Product"]}}'
+
+# With custom target file
+teds generate '{"schema.yaml": {"paths": ["$.$defs.*"], "target": "custom_tests.yaml"}}'
+----
+
+===== Method 3: Simple List Format
+
+[source,bash]
+----
+# Simplified syntax for multiple paths
+teds generate '{"schema.yaml": ["$.components.schemas.*", "$.$defs.*"]}'
+----
+
+**JSON Path Examples:**
+
+[source,yaml]
+----
+# Configuration examples (can be in files or direct arguments)
+
+# Select ALL schemas under components/schemas
+sample_schemas.yaml:
+  paths: ["$.components.schemas.*"]
+
+# Select specific schemas by name
+api.yaml:
+  paths: ["$.components.schemas.User", "$.components.schemas.Email"]
+
+# Array indices and wildcards
+complex.yaml:
+  paths: ["$.$defs.*", "$.allOf[0]", "$.items[1]"]
+  target: "complex_tests.yaml"
+
+# Nested selections
+nested.yaml:
+  paths: ["$.components.schemas.*.properties"]
 ----
 
 **Key differences:**
 
 * **JSON Pointer**: `#/components/schemas` → finds schemas directly at this location
 * **JSON Path**: `$.components.schemas.*` → requires `*` wildcard to select multiple items
+* **JSON Path usage**: Via YAML/JSON config objects using `@file`, direct strings, or simple lists
 
 ==== Practical Examples
 
@@ -240,9 +289,9 @@ teds generate api_spec.yaml#/components/schemas/User/properties
 # AVOID: Single schema without properties - limited test generation
 # teds generate api_spec.yaml#/components/schemas/User
 
-# Reading paths from file
-echo "api_spec.yaml#/components/schemas" > schema_refs.txt
-teds generate --from-file schema_refs.txt
+# Using configuration file with JSON Path
+echo 'api_spec.yaml: ["$.components.schemas.*"]' > config.yaml
+teds generate @config.yaml
 ----
 
 This creates `api_spec.components+schemas.tests.yaml` with test cases derived from the `examples` in each schema found at the specified location.
@@ -635,7 +684,7 @@ teds generate schema.yaml#/components/schemas --target-template "{base}.{pointer
 # {index}    - 1, 2, 3... (for multiple targets)
 ----
 
-**Important**: Template variables only work with JSON Pointer syntax (`#/path`), not with JSON Path (`--json-path`).
+**Important**: Template variables only work with JSON Pointer syntax (`#/path`), not with JSON Path configuration objects.
 
 ==== Pointer Sanitization with Plus Signs
 

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -821,18 +821,69 @@ teds generate sample_schemas.yaml#/components/schemas/Email</code></pre>
 <div class="sect3">
 <h4 id="_json_path_alternative_method"><a class="link" href="#_json_path_alternative_method">4.3.2. JSON Path (Alternative Method)</a></h4>
 <div class="paragraph">
-<p><strong>JSON Path</strong> uses CSS-like selector syntax and requires <strong>explicit wildcards</strong> to select multiple elements:</p>
+<p><strong>JSON Path</strong> uses CSS-like selector syntax and requires <strong>explicit wildcards</strong> to select multiple elements. TeDS supports JSON Path through YAML/JSON configuration objects in three ways:</p>
+</div>
+<div class="sect4">
+<h5 id="_method_1_configuration_files"><a class="link" href="#_method_1_configuration_files">Method 1: Configuration Files</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash"># Create a configuration file
+cat &gt; config.yaml &lt;&lt; EOF
+sample_schemas.yaml:
+  paths: ["$.components.schemas.*"]
+EOF
+
+# Generate using @file syntax
+teds generate @config.yaml</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_method_2_direct_yamljson_arguments"><a class="link" href="#_method_2_direct_yamljson_arguments">Method 2: Direct YAML/JSON Arguments</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash"># Pass configuration directly as YAML/JSON string
+teds generate '{"sample_schemas.yaml": {"paths": ["$.components.schemas.*"]}}'
+
+# Multiple paths in one schema
+teds generate '{"api.yaml": {"paths": ["$.components.schemas.User", "$.components.schemas.Product"]}}'
+
+# With custom target file
+teds generate '{"schema.yaml": {"paths": ["$.$defs.*"], "target": "custom_tests.yaml"}}'</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_method_3_simple_list_format"><a class="link" href="#_method_3_simple_list_format">Method 3: Simple List Format</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash"># Simplified syntax for multiple paths
+teds generate '{"schema.yaml": ["$.components.schemas.*", "$.$defs.*"]}'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>JSON Path Examples:</strong></p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash"># Select ALL schemas under components/schemas (equivalent to JSON Pointer above)
-teds generate sample_schemas.yaml --json-path '$.components.schemas.*'
+<pre class="highlightjs highlight"><code class="language-yaml hljs" data-lang="yaml"># Configuration examples (can be in files or direct arguments)
 
-# Select specific schemas by name pattern
-teds generate sample_schemas.yaml --json-path '$.components.schemas[User,Email,Product]'
+# Select ALL schemas under components/schemas
+sample_schemas.yaml:
+  paths: ["$.components.schemas.*"]
 
-# Select schemas at any level that match a pattern
-teds generate sample_schemas.yaml --json-path '$..schemas[?(@.type=="object")]'</code></pre>
+# Select specific schemas by name
+api.yaml:
+  paths: ["$.components.schemas.User", "$.components.schemas.Email"]
+
+# Array indices and wildcards
+complex.yaml:
+  paths: ["$.$defs.*", "$.allOf[0]", "$.items[1]"]
+  target: "complex_tests.yaml"
+
+# Nested selections
+nested.yaml:
+  paths: ["$.components.schemas.*.properties"]</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -846,7 +897,11 @@ teds generate sample_schemas.yaml --json-path '$..schemas[?(@.type=="object")]'<
 <li>
 <p><strong>JSON Path</strong>: <code>$.components.schemas.<strong></code> → requires <code></strong></code> wildcard to select multiple items</p>
 </li>
+<li>
+<p><strong>JSON Path usage</strong>: Via YAML/JSON config objects using <code>@file</code>, direct strings, or simple lists</p>
+</li>
 </ul>
+</div>
 </div>
 </div>
 <div class="sect3">
@@ -862,9 +917,9 @@ teds generate api_spec.yaml#/components/schemas/User/properties
 # AVOID: Single schema without properties - limited test generation
 # teds generate api_spec.yaml#/components/schemas/User
 
-# Reading paths from file
-echo "api_spec.yaml#/components/schemas" &gt; schema_refs.txt
-teds generate --from-file schema_refs.txt</code></pre>
+# Using configuration file with JSON Path
+echo 'api_spec.yaml: ["$.components.schemas.*"]' &gt; config.yaml
+teds generate @config.yaml</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1328,7 +1383,7 @@ teds generate schema.yaml#/components/schemas --target-template "{base}.{pointer
 </div>
 </div>
 <div class="paragraph">
-<p><strong>Important</strong>: Template variables only work with JSON Pointer syntax (<code>#/path</code>), not with JSON Path (<code>--json-path</code>).</p>
+<p><strong>Important</strong>: Template variables only work with JSON Pointer syntax (<code>#/path</code>), not with JSON Path configuration objects.</p>
 </div>
 <div class="sect3">
 <h4 id="_pointer_sanitization_with_plus_signs"><a class="link" href="#_pointer_sanitization_with_plus_signs">8.4.1. Pointer Sanitization with Plus Signs</a></h4>
@@ -1703,7 +1758,7 @@ teds verify user_generated.tests.yaml --in-place
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2025-09-22 23:59:50 +0200
+Last updated 2025-09-23 00:24:30 +0200
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>


### PR DESCRIPTION
## Summary
This PR corrects significant errors in the tutorial's JSON Path documentation that referenced non-existent CLI options.

## Changes Made
- ❌ **Removed**: Non-existent `--json-path` CLI option references
- ❌ **Removed**: Non-existent `--from-file` CLI option references  
- ✅ **Added**: Correct documentation of actual JSON Path implementation

## Corrected JSON Path Documentation
Now properly documents the three supported methods:

### 1. Configuration Files
```bash
teds generate @config.yaml
```

### 2. Direct YAML/JSON Arguments  
```bash
teds generate '{"schema.yaml": {"paths": ["$.components.schemas.*"]}}'
```

### 3. Simple List Format
```bash
teds generate '{"schema.yaml": ["$.components.schemas.*", "$.$defs.*"]}'
```

## Test Plan
- [x] Verify all CLI options mentioned in tutorial actually exist
- [x] Test documented JSON Path syntaxes work as described
- [x] Remove all references to non-existent options
- [x] Add comprehensive examples for each method
- [x] Regenerate tutorial.html with correct information

## Before/After
**Before**: Tutorial referenced `--json-path` and `--from-file` options that don't exist
**After**: Tutorial accurately documents the actual JSON Path implementation via YAML/JSON configuration objects

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)