### PR TITLE
Fix: Restore invalid test cases and correct validation error expectations

### DIFF
--- a/tests/bdd/features/cli_argument_parsing.feature
+++ b/tests/bdd/features/cli_argument_parsing.feature
@@ -70,6 +70,10 @@ Feature: CLI Argument Parsing
             good email:
               description: simple valid email
               payload: alice@example.com
+          invalid:
+            "not an email":
+              description: not a valid email address
+              payload: "not-an-email"
         sample_schemas.yaml#/components/schemas/User:
           valid:
             minimal valid user:
@@ -82,9 +86,16 @@ Feature: CLI Argument Parsing
               description: payload provided as JSON string
               parse_payload: true
               payload: "{\"id\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\"name\":\"Bob Builder\",\"email\":\"bob@example.com\"}"
+          invalid:
+            bad uuid:
+              description: id is not a valid UUID
+              payload:
+                id: "not-a-uuid"
+                name: "Alice Example"
+                email: "alice@example.com"
       """
     When I run the command "verify --output-level all --report default.adoc sample_tests.yaml"
-    Then the command should succeed
+    Then the command should complete with validation errors
     And a file "sample_tests.report.adoc" should be created
 
   Scenario: Output-level warning with report should work fine


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where invalid test cases were incorrectly removed and test expectations were changed to expect success instead of validation errors.

## Problem Fixed
The BDD test "Output-level all with report should work with real demo data" had its:
- Invalid test cases removed (❌ wrong)
- Test expectation changed to "success" instead of "validation errors" (❌ wrong)
- Original test purpose destroyed (❌ unacceptable)

## Solution
- ✅ Restored all invalid test cases with problematic payloads
- ✅ Set correct expectation: "command should complete with validation errors" (exit code 1)
- ✅ Maintained original test purpose: validate error handling with realistic demo data
- ✅ Test now properly verifies TeDS detects validation errors

## Test Cases Validated
The test now correctly validates that TeDS identifies validation errors in:
- **Email schema**: `"not-an-email"` payload should trigger validation error
- **User schema**: `"not-a-uuid"` id field should trigger validation error

## Test Results
- All 13 BDD tests pass ✅
- Test properly expects exit code 1 for validation errors ✅
- Original test purpose preserved ✅

This ensures the test maintains its important role in validating TeDS error handling capabilities.