### PR TITLE
fix: resolve package-smoke workflow path resolution failure

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -58,6 +58,8 @@ jobs:
           echo "verify rc: $rc"
           test "$rc" -eq 1
           # generate smoke
-          teds generate "$REPO/demo/sample_schemas.yaml=$run_dir/smoke.tests.yaml"
+          # Copy schema file to temp dir to avoid path resolution issues
+          cp "$REPO/demo/sample_schemas.yaml" "$run_dir/sample_schemas.yaml"
+          teds generate "sample_schemas.yaml=$run_dir/smoke.tests.yaml"
           test -f "$run_dir/smoke.tests.yaml"
           deactivate


### PR DESCRIPTION
## Problem

The package-smoke workflow was failing with the same path resolution issue as the release workflow:

```
Warning: Failed to generate from 'sample_schemas.yaml#/asyncapi': [Errno 2] No such file or directory: '/tmp/tmp.geHMz5Tbis/sample_schemas.yaml'
```

This occurs because:
1. The workflow changes to a temporary directory (`cd "$run_dir"`)
2. The generate command tries to find `sample_schemas.yaml` relative to current directory  
3. The file doesn't exist in the temp directory

## Solution

Applied the same fix as PR #80 for the release workflow:

```bash
# Copy schema file to temp dir to avoid path resolution issues
cp "$REPO/demo/sample_schemas.yaml" "$run_dir/sample_schemas.yaml"
teds generate "sample_schemas.yaml=$run_dir/smoke.tests.yaml"
```

## Testing

This fix ensures both package-smoke and release workflows work properly by making the schema file available in the working directory where the generate command executes.

This resolves the failing package-smoke CI checks that were blocking development workflow.