### PR TITLE
feat: add CLI shorthand and comprehensive address list examples

### DIFF
--- a/examples/address_list/address_list.tests.yaml
+++ b/examples/address_list/address_list.tests.yaml
@@ -1,2 +1,20 @@
 version: 1.0.0
-tests: {}
+tests:
+  address_list.yaml#/$defs/AddressOneLine:
+    valid:
+      .["$defs"].AddressOneLine.examples[0]:
+        payload:
+          one_line_address: Meine-Straße 1, 76136 Anytown
+        from_examples: true
+    invalid:
+  address_list.yaml#/$defs/AddressTwoLines:
+    valid:
+      .["$defs"].AddressTwoLines.examples[0]:
+        payload:
+          street_and_housenumber: Meine-Straße 1
+          zip_and_city: 76136 Anytown
+        from_examples: true
+    invalid:
+  address_list.yaml#/$defs/AddressList:
+    valid:
+    invalid:

--- a/teds_core/cli.py
+++ b/teds_core/cli.py
@@ -296,6 +296,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_verify.add_argument("spec", nargs="+", help="YAML testspec file(s)")
     p_verify.add_argument(
+        "-l",
         "--output-level",
         choices=["all", "warning", "error"],
         default="warning",


### PR DESCRIPTION
## Summary

Two user experience improvements:

### 1. CLI Enhancement: Add `-l` shorthand
- Add `-l` as shorthand for `--output-level` in verify command
- Improves CLI ergonomics for frequent use: `teds verify spec.yaml -l error`
- Backward compatible with existing `--output-level` usage

### 2. Complete Address List Example
- Transform empty `address_list.tests.yaml` into comprehensive example
- Add real test cases for `AddressOneLine` and `AddressTwoLines` based on schema examples
- Include `from_examples: true` to demonstrate schema-driven testing
- Provide template for `AddressList` tests (ready for extension)

## Benefits

- **Better UX**: Shorter command line for common operations
- **Complete Example**: Shows how to write effective test specifications
- **Documentation**: Demonstrates `from_examples` feature usage
- **Template**: Provides pattern for users to follow in their own schemas

## Testing

- All pre-commit hooks pass
- Unit tests and BDD tests pass
- CLI functionality verified