### PR TITLE
fix: include user warnings in report message column across all templates

### DIFF
--- a/templates/default.adoc.j2
+++ b/templates/default.adoc.j2
@@ -138,7 +138,11 @@ a| [source,yaml]
 {% else %}
 | [gray]#○ UNKNOWN#
 {% endif %}
-| {% if case_data.message %}{{ case_data.message }}{% endif %}
+| {% if case_data.message %}{{ case_data.message }}{% endif %}{% if case_data.warnings %}{% if case_data.message %} +
++
+*Warnings:*{% else %}*Warnings:*{% endif %}{% for warning in case_data.warnings %}{% if warning is string %} +
+• {{ warning }}{% else %} +
+• {{ warning.generated }}{% endif %}{% endfor %}{% endif %}
 {% endfor %}
 |===
 {% endif %}
@@ -165,7 +169,11 @@ a| [source,yaml]
 {% else %}
 | [gray]#○ UNKNOWN#
 {% endif %}
-| {% if case_data.message %}{{ case_data.message }}{% endif %}
+| {% if case_data.message %}{{ case_data.message }}{% endif %}{% if case_data.warnings %}{% if case_data.message %} +
++
+*Warnings:*{% else %}*Warnings:*{% endif %}{% for warning in case_data.warnings %}{% if warning is string %} +
+• {{ warning }}{% else %} +
+• {{ warning.generated }}{% endif %}{% endfor %}{% endif %}
 {% endfor %}
 |===
 {% endif %}

--- a/templates/default.html.j2
+++ b/templates/default.html.j2
@@ -294,7 +294,7 @@
                     <span class="status-unknown">○ UNKNOWN</span>
                     {% endif %}
                 </td>
-                <td>{% if case_data.message %}{{ case_data.message }}{% endif %}</td>
+                <td>{% if case_data.message %}{{ case_data.message }}{% endif %}{% if case_data.warnings %}{% if case_data.message %}<br><br>{% endif %}<strong>Warnings:</strong><ul>{% for warning in case_data.warnings %}{% if warning is string %}<li>{{ warning }}</li>{% else %}<li>{{ warning.generated }}</li>{% endif %}{% endfor %}</ul>{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -324,7 +324,7 @@
                     <span class="status-unknown">○ UNKNOWN</span>
                     {% endif %}
                 </td>
-                <td>{% if case_data.message %}{{ case_data.message }}{% endif %}</td>
+                <td>{% if case_data.message %}{{ case_data.message }}{% endif %}{% if case_data.warnings %}{% if case_data.message %}<br><br>{% endif %}<strong>Warnings:</strong><ul>{% for warning in case_data.warnings %}{% if warning is string %}<li>{{ warning }}</li>{% else %}<li>{{ warning.generated }}</li>{% endif %}{% endfor %}</ul>{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/templates/default.md.j2
+++ b/templates/default.md.j2
@@ -115,7 +115,11 @@ This report analyzes **{{ doc.tests|length }}** schema(s) with a total of **{{ s
 
 {% if case_data.message %}
 **Message:** {{ case_data.message }}
-{% endif %}
+{% endif %}{% if case_data.warnings %}
+**Warnings:**
+{% for warning in case_data.warnings %}{% if warning is string %}• {{ warning }}
+{% else %}• {{ warning.generated }}
+{% endif %}{% endfor %}{% endif %}
 
 ---
 
@@ -137,7 +141,11 @@ This report analyzes **{{ doc.tests|length }}** schema(s) with a total of **{{ s
 
 {% if case_data.message %}
 **Message:** {{ case_data.message }}
-{% endif %}
+{% endif %}{% if case_data.warnings %}
+**Warnings:**
+{% for warning in case_data.warnings %}{% if warning is string %}• {{ warning }}
+{% else %}• {{ warning.generated }}
+{% endif %}{% endfor %}{% endif %}
 
 ---
 


### PR DESCRIPTION
## Problem
User-defined warnings in test cases were not displayed in report templates, causing important information to be invisible despite WARNING status being correctly shown.

For example, this test case had a WARNING status but no message:
```yaml
email contact:
  payload: { email: someone@example.com }
  warnings:
    - "If E.164-only is desired, tighten the schema..."
```

## Solution  
Updated all three report templates to include warnings in the message column:

### Changes Made
- **default.adoc.j2**: Add warnings with bullet points using AsciiDoc formatting
- **default.md.j2**: Display warnings as bulleted list in Markdown
- **default.html.j2**: Render warnings as styled HTML list

### Features
- ✅ Support both string warnings and structured warnings (`generated` field)
- ✅ Proper formatting with bullet points for readability
- ✅ Conditional rendering (warnings only shown if present)
- ✅ Separation between messages and warnings when both exist

## Before/After
**Before:** WARNING status shown, but no warning text visible in reports  
**After:** All user-defined warnings displayed clearly in message column

## Testing
Verified with `demo/sample_tests.yaml` across all three template formats - warnings now appear correctly in all reports.