### PR TITLE
feat: enhance HTML report with left-side TOC and schema depth navigation

### DIFF
--- a/demo/sample_tests.report.adoc
+++ b/demo/sample_tests.report.adoc
@@ -13,10 +13,10 @@
 
 [cols="1,3"]
 |===
-| Tool Version | teds 0.1.dev13+g9e84ef6db.d20250920
+| Tool Version | teds 0.7.5
 | Specification Support | 1.0-1.0
 | Recommended Version | 1.0
-| Generated | 2025-09-22T15:26:35.550549+02:00
+| Generated | 2025-09-29T15:20:11.095613+02:00
 | Report File | demo/sample_tests.yaml
 |===
 
@@ -36,75 +36,75 @@
 
 
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
+  
+  
 
+  
+  
+  
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  
+  
 
 
 [.lead]
@@ -171,7 +171,7 @@ alice@example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.Email.examples[1]`
 a| [source,yaml]
@@ -181,7 +181,11 @@ not-an-email
 
 | [yellow]#⚠ WARNING#
 
-|
+| *Warnings:* +
+• Relies on JSON Schema 'format' assertion (format: email).
+Validators that *enforce* 'format' will reject this instance.
+Consider enforcing the expected format by adding an explicit 'pattern' property to the schema.
+
 
 | `good email`
 a| [source,yaml]
@@ -191,7 +195,7 @@ alice@example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -257,7 +261,7 @@ email: alice@example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.User.examples[1]`
 a| [source,yaml]
@@ -281,7 +285,7 @@ email: alice@example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `parse as JSON string`
 a| [source,yaml]
@@ -291,7 +295,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -393,7 +397,7 @@ AB-123
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.Identifier.examples[1]`
 a| [source,yaml]
@@ -403,7 +407,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `AB-777`
 a| [source,yaml]
@@ -413,7 +417,7 @@ undefined
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `forty-two`
 a| [source,yaml]
@@ -423,7 +427,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -495,7 +499,7 @@ green
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `simple enum ok`
 a| [source,yaml]
@@ -505,7 +509,7 @@ red
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -567,7 +571,7 @@ abc12
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `regex ok`
 a| [source,yaml]
@@ -577,7 +581,7 @@ abc12
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -644,7 +648,7 @@ color: red
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `full product`
 a| [source,yaml]
@@ -659,7 +663,7 @@ color: blue
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `json string`
 a| [source,yaml]
@@ -669,7 +673,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -707,7 +711,10 @@ tags:
 
 | [yellow]#⚠ WARNING#
 
-| [{'key': 'env', 'value': 'prod'}, {'key': 'env', 'value': 'prod'}] has non-unique elements
+| [{'key': 'env', 'value': 'prod'}, {'key': 'env', 'value': 'prod'}] has non-unique elements +
++
+*Warnings:* +
+• Hyphenated SKUs are common in some systems; consider relaxing the pattern to allow '-' if business rules permit.
 
 |===
 
@@ -748,7 +755,7 @@ email: someone@example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.Contact.examples[1]`
 a| [source,yaml]
@@ -758,7 +765,7 @@ phone: +49 621 1234567
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.Contact.examples[2]`
 a| [source,yaml]
@@ -779,7 +786,8 @@ email: someone@example.com
 
 | [yellow]#⚠ WARNING#
 
-|
+| *Warnings:* +
+• If E.164-only is desired, tighten the schema (e.g., require '+' and country code) and normalize producers.
 
 | `parse json string`
 a| [source,yaml]
@@ -789,7 +797,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -854,7 +862,7 @@ quantity: 2
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.OrderLine.examples[1]`
 a| [source,yaml]
@@ -867,7 +875,7 @@ items:
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `.components.schemas.OrderLine.examples[2]`
 a| [source,yaml]
@@ -894,7 +902,7 @@ quantity: 2
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `bundled ok`
 a| [source,yaml]
@@ -907,7 +915,7 @@ items:
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `priced via json string`
 a| [source,yaml]
@@ -917,7 +925,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -1006,7 +1014,7 @@ https://example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `good uri`
 a| [source,yaml]
@@ -1016,7 +1024,7 @@ https://example.com
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -1080,7 +1088,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 | `good date`
 a| [source,yaml]
@@ -1090,7 +1098,7 @@ a| [source,yaml]
 
 | [green]#✓ SUCCESS#
 
-|
+| 
 
 |===
 
@@ -1129,10 +1137,10 @@ Consider enforcing the expected format by adding an explicit 'pattern' property 
 
 [cols="1,3"]
 |===
-| TeDS Version | 0.1.dev13+g9e84ef6db.d20250920
+| TeDS Version | 0.7.5
 | Supported Spec Range | 1.0-1.0
 | Recommended Spec Version | 1.0
-| Report Generation Time | 2025-09-22T15:26:35.550549+02:00
+| Report Generation Time | 2025-09-29T15:20:11.095613+02:00
 |===
 
 === Report Scope

--- a/demo/sample_tests.report.html
+++ b/demo/sample_tests.report.html
@@ -10,10 +10,10 @@
             font-family: "Noto Serif", "DejaVu Serif", serif;
             line-height: 1.6;
             color: #222;
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 20px;
+            margin: 0;
+            padding: 0;
             background: #fff;
+            display: flex;
         }
 
         h1, h2, h3, h4 {
@@ -120,10 +120,16 @@
 
         .toc {
             background: #f8f9fa;
-            border: 1px solid #ddd;
+            border-right: 1px solid #ddd;
             padding: 1em;
-            margin: 1em 0;
-            border-radius: 4px;
+            margin: 0;
+            border-radius: 0;
+            width: 300px;
+            min-height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            overflow-y: auto;
         }
 
         .toc h3 {
@@ -148,20 +154,163 @@
         .toc a:hover {
             text-decoration: underline;
         }
+
+        .content {
+            margin-left: 320px;
+            padding: 20px;
+            max-width: 1200px;
+            flex: 1;
+        }
+
+        .toc ul ul {
+            padding-left: 1em;
+        }
+
+        .toc ul ul ul {
+            padding-left: 2em;
+        }
     </style>
 </head>
 <body>
-    <h1 id="teds-default-validation-report">TeDS Default Validation Report</h1>
-
     <div class="toc">
         <h3>Table of Contents</h3>
         <ul>
+            <li><a href="#teds-default-validation-report">TeDS Default Validation Report</a></li>
             <li><a href="#overview">Overview</a></li>
             <li><a href="#executive-summary">Executive Summary</a></li>
-            <li><a href="#detailed-results">Detailed Results</a></li>
+            <li><a href="#detailed-results">Detailed Results</a>
+                
+                <ul>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_Email">sample_schemas.yaml#/components/schemas/Email</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Email-valid">Valid Cases (3)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Email-invalid">Invalid Cases (1)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_User">sample_schemas.yaml#/components/schemas/User</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_User-valid">Valid Cases (4)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_User-invalid">Invalid Cases (4)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_Identifier">sample_schemas.yaml#/components/schemas/Identifier</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Identifier-valid">Valid Cases (4)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Identifier-invalid">Invalid Cases (2)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_Color">sample_schemas.yaml#/components/schemas/Color</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Color-valid">Valid Cases (2)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Color-invalid">Invalid Cases (1)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_Regexy">sample_schemas.yaml#/components/schemas/Regexy</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Regexy-valid">Valid Cases (2)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Regexy-invalid">Invalid Cases (1)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_Product">sample_schemas.yaml#/components/schemas/Product</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Product-valid">Valid Cases (3)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Product-invalid">Invalid Cases (2)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_Contact">sample_schemas.yaml#/components/schemas/Contact</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Contact-valid">Valid Cases (5)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_Contact-invalid">Invalid Cases (1)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_OrderLine">sample_schemas.yaml#/components/schemas/OrderLine</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_OrderLine-valid">Valid Cases (6)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_OrderLine-invalid">Invalid Cases (3)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_URI">sample_schemas.yaml#/components/schemas/URI</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_URI-valid">Valid Cases (2)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_URI-invalid">Invalid Cases (1)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                    
+                    <li><a href="#sample_schemas_yaml__components_schemas_DateISO">sample_schemas.yaml#/components/schemas/DateISO</a>
+                        
+                        
+                        
+                        <ul>
+                            <li><a href="#sample_schemas_yaml__components_schemas_DateISO-valid">Valid Cases (2)</a></li>
+                            <li><a href="#sample_schemas_yaml__components_schemas_DateISO-invalid">Invalid Cases (1)</a></li>
+                        </ul>
+                        
+                    </li>
+                    
+                </ul>
+                
+            </li>
             <li><a href="#appendix">Appendix</a></li>
         </ul>
     </div>
+
+    <div class="content">
+        <h1 id="teds-default-validation-report">TeDS Default Validation Report</h1>
 
     <h2 id="overview">Overview</h2>
 
@@ -170,7 +319,7 @@
             <tr><th>Tool Version</th><td>teds 0.7.5</td></tr>
             <tr><th>Specification Support</th><td>1.0-1.0</td></tr>
             <tr><th>Recommended Version</th><td>1.0</td></tr>
-            <tr><th>Generated</th><td>2025-09-28T23:30:05.515323+02:00</td></tr>
+            <tr><th>Generated</th><td>2025-09-29T18:21:19.412623+02:00</td></tr>
             <tr><th>Report File</th><td>demo/sample_tests.yaml</td></tr>
         </tbody>
     </table>
@@ -313,7 +462,7 @@
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Email-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -340,7 +489,10 @@
                     <span class="status-warning">⚠ WARNING</span>
                     
                 </td>
-                <td></td>
+                <td><strong>Warnings:</strong><ul><li>Relies on JSON Schema 'format' assertion (format: email).
+Validators that *enforce* 'format' will reject this instance.
+Consider enforcing the expected format by adding an explicit 'pattern' property to the schema.
+</li></ul></td>
             </tr>
             
             <tr>
@@ -359,7 +511,7 @@
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Email-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -405,7 +557,7 @@ Consider enforcing the expected format by adding an explicit 'pattern' property 
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_User-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -468,7 +620,7 @@ email: alice@example.com</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_User-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -555,7 +707,7 @@ email: alice@example.com</div></td>
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Identifier-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -612,7 +764,7 @@ email: alice@example.com</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Identifier-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -667,7 +819,7 @@ email: alice@example.com</div></td>
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Color-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -702,7 +854,7 @@ email: alice@example.com</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Color-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -746,7 +898,7 @@ email: alice@example.com</div></td>
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Regexy-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -781,7 +933,7 @@ email: alice@example.com</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Regexy-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -825,7 +977,7 @@ email: alice@example.com</div></td>
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Product-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -881,7 +1033,7 @@ color: blue</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Product-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -915,7 +1067,7 @@ tags:
                     <span class="status-warning">⚠ WARNING</span>
                     
                 </td>
-                <td>[{'key': 'env', 'value': 'prod'}, {'key': 'env', 'value': 'prod'}] has non-unique elements</td>
+                <td>[{'key': 'env', 'value': 'prod'}, {'key': 'env', 'value': 'prod'}] has non-unique elements<br><br><strong>Warnings:</strong><ul><li>Hyphenated SKUs are common in some systems; consider relaxing the pattern to allow '-' if business rules permit.</li></ul></td>
             </tr>
             
         </tbody>
@@ -943,7 +1095,7 @@ tags:
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Contact-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -993,7 +1145,7 @@ phone: +49 621 1234567</div></td>
                     <span class="status-warning">⚠ WARNING</span>
                     
                 </td>
-                <td></td>
+                <td><strong>Warnings:</strong><ul><li>If E.164-only is desired, tighten the schema (e.g., require '+' and country code) and normalize producers.</li></ul></td>
             </tr>
             
             <tr>
@@ -1012,7 +1164,7 @@ phone: +49 621 1234567</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_Contact-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -1057,7 +1209,7 @@ phone: +49 621 1234567</div></td>
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_OrderLine-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -1151,7 +1303,7 @@ items:
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_OrderLine-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -1224,7 +1376,7 @@ quantity: 0</div></td>
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_URI-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -1259,7 +1411,7 @@ quantity: 0</div></td>
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_URI-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -1305,7 +1457,7 @@ Consider enforcing the expected format by adding an explicit 'pattern' property 
     </table>
 
     
-    <h4>Valid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_DateISO-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -1340,7 +1492,7 @@ Consider enforcing the expected format by adding an explicit 'pattern' property 
     
 
     
-    <h4>Invalid Test Cases</h4>
+    <h4 id="sample_schemas_yaml__components_schemas_DateISO-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -1379,7 +1531,7 @@ Consider enforcing the expected format by adding an explicit 'pattern' property 
             <tr><th>TeDS Version</th><td>0.7.5</td></tr>
             <tr><th>Supported Spec Range</th><td>1.0-1.0</td></tr>
             <tr><th>Recommended Spec Version</th><td>1.0</td></tr>
-            <tr><th>Report Generation Time</th><td>2025-09-28T23:30:05.515323+02:00</td></tr>
+            <tr><th>Report Generation Time</th><td>2025-09-29T18:21:19.412623+02:00</td></tr>
         </tbody>
     </table>
 
@@ -1397,8 +1549,9 @@ Consider enforcing the expected format by adding an explicit 'pattern' property 
 
     <p>For questions about this report or TeDS functionality, please refer to the TeDS documentation.</p>
 
-    <div class="footer">
-        <p>This report was generated automatically by TeDS (Test-Driven Schema Development Tool).</p>
+        <div class="footer">
+            <p>This report was generated automatically by TeDS (Test-Driven Schema Development Tool).</p>
+        </div>
     </div>
 
 </body>

--- a/templates/default.html.j2
+++ b/templates/default.html.j2
@@ -10,10 +10,10 @@
             font-family: "Noto Serif", "DejaVu Serif", serif;
             line-height: 1.6;
             color: #222;
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 20px;
+            margin: 0;
+            padding: 0;
             background: #fff;
+            display: flex;
         }
 
         h1, h2, h3, h4 {
@@ -120,10 +120,16 @@
 
         .toc {
             background: #f8f9fa;
-            border: 1px solid #ddd;
+            border-right: 1px solid #ddd;
             padding: 1em;
-            margin: 1em 0;
-            border-radius: 4px;
+            margin: 0;
+            border-radius: 0;
+            width: 300px;
+            min-height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            overflow-y: auto;
         }
 
         .toc h3 {
@@ -148,20 +154,55 @@
         .toc a:hover {
             text-decoration: underline;
         }
+
+        .content {
+            margin-left: 320px;
+            padding: 20px;
+            max-width: 1200px;
+            flex: 1;
+        }
+
+        .toc ul ul {
+            padding-left: 1em;
+        }
+
+        .toc ul ul ul {
+            padding-left: 2em;
+        }
     </style>
 </head>
 <body>
-    <h1 id="teds-default-validation-report">TeDS Default Validation Report</h1>
-
     <div class="toc">
         <h3>Table of Contents</h3>
         <ul>
+            <li><a href="#teds-default-validation-report">TeDS Default Validation Report</a></li>
             <li><a href="#overview">Overview</a></li>
             <li><a href="#executive-summary">Executive Summary</a></li>
-            <li><a href="#detailed-results">Detailed Results</a></li>
+            <li><a href="#detailed-results">Detailed Results</a>
+                {% if inputs[0].doc.tests %}
+                <ul>
+                    {% for ref, grp in inputs[0].doc.tests.items() %}
+                    {% set ref_anchor = ref.replace('/', '_').replace('#', '_').replace('.', '_') %}
+                    <li><a href="#{{ ref_anchor }}">{{ ref }}</a>
+                        {% set valid_cases = (grp.valid or {}) %}
+                        {% set invalid_cases = (grp.invalid or {}) %}
+                        {% if valid_cases or invalid_cases %}
+                        <ul>
+                            {% if valid_cases %}<li><a href="#{{ ref_anchor }}-valid">Valid Cases ({{ valid_cases|length }})</a></li>{% endif %}
+                            {% if invalid_cases %}<li><a href="#{{ ref_anchor }}-invalid">Invalid Cases ({{ invalid_cases|length }})</a></li>{% endif %}
+                        </ul>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </li>
             <li><a href="#appendix">Appendix</a></li>
         </ul>
     </div>
+
+    <div class="content">
+        <h1 id="teds-default-validation-report">TeDS Default Validation Report</h1>
 
     <h2 id="overview">Overview</h2>
 
@@ -272,7 +313,7 @@
     </table>
 
     {% if valid_cases %}
-    <h4>Valid Test Cases</h4>
+    <h4 id="{{ ref_anchor }}-valid">Valid Test Cases</h4>
 
     <table>
         <thead>
@@ -302,7 +343,7 @@
     {% endif %}
 
     {% if invalid_cases %}
-    <h4>Invalid Test Cases</h4>
+    <h4 id="{{ ref_anchor }}-invalid">Invalid Test Cases</h4>
 
     <table>
         <thead>
@@ -367,8 +408,9 @@
 
     <p>For questions about this report or TeDS functionality, please refer to the TeDS documentation.</p>
 
-    <div class="footer">
-        <p>This report was generated automatically by TeDS (Test-Driven Schema Development Tool).</p>
+        <div class="footer">
+            <p>This report was generated automatically by TeDS (Test-Driven Schema Development Tool).</p>
+        </div>
     </div>
 
 </body>


### PR DESCRIPTION
## Summary
- Enhanced HTML report template with fixed left sidebar table of contents
- Added comprehensive navigation hierarchy showing all schema levels
- Improved navigation to valid/invalid test case sections with counts

## Changes
- Moved TOC to fixed 300px left sidebar with responsive flexbox layout
- Added nested navigation for schemas with direct links to test sections
- Enhanced styling with proper content margin and multi-level list indentation
- Fixed template variable references for proper schema enumeration

## Test plan
- [x] Generated test report to verify template functionality
- [x] Verified left-side TOC positioning and navigation links
- [x] Confirmed hierarchical schema navigation with valid/invalid sections
- [x] Tested responsive layout and scrolling behavior

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)