### PR TITLE
fix: resolve schema paths consistently relative to CWD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,3 +349,13 @@ pytest tests/unit/test_new_feature.py::test_my_feature -v  # Must pass
 - ✅ Always run coverage verification before committing
 
 **This is a permanent, non-negotiable requirement that must ALWAYS be followed.**
+
+## Pull Request Guidelines
+
+**Test Coverage in PR Descriptions:**
+- ❌ **NEVER include test coverage details** in PR descriptions unless coverage is the main topic of the PR
+- ❌ Avoid mentioning "X tests pass", "Y% coverage", test counts, etc.
+- ✅ Focus on **business value**, **problem solved**, and **technical changes**
+- ✅ Only mention testing when it's directly relevant to the change (e.g., "Add tests for new feature")
+
+**Rationale:** Test coverage is an implementation detail, not user value. PRs should focus on what problem is solved and how.

--- a/teds_core/generate.py
+++ b/teds_core/generate.py
@@ -439,12 +439,9 @@ def generate_from_source_config(
             )
 
         # Determine schema file path for JsonPath expansion
-        if source_config["target"]:
-            # For explicit targets, schema paths are relative to target directory
-            schema_file = target_path.parent / source_file_str
-        else:
-            # For default targets, schema paths are relative to working directory
-            schema_file = base_dir / source_file_str
+        # Schema paths are always relative to working directory (base_dir)
+        # This ensures consistent behavior regardless of target specification
+        schema_file = base_dir / source_file_str
 
         # Calculate correct reference path relative to test file directory
         try:

--- a/tests/load/agriculture/agriculture.tests.yaml
+++ b/tests/load/agriculture/agriculture.tests.yaml
@@ -1,0 +1,72 @@
+version: 1.0.0
+tests:
+  agriculture.yaml#/$defs/Farm:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/Field:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/Crop:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/Livestock:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/Vaccination:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/BreedingRecord:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/IrrigationSystem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/Equipment:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/FieldOperation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  agriculture.yaml#/$defs/Material:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/agriculture/agriculture.yaml
+++ b/tests/load/agriculture/agriculture.yaml
@@ -1,6 +1,150 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Agricultural Management System Schema"
 type: object
+examples:
+  - farms:
+      - farm_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Green Valley Farm"
+        owner:
+          first_name: "John"
+          middle_name: "Robert"
+          last_name: "Smith"
+        address:
+          street: "1234 Farm Road"
+          city: "Greenfield"
+          state: "Iowa"
+          postal_code: "50849"
+          country: "United States"
+        total_area_hectares: 240.5
+        farm_type: "mixed"
+        established_date: "2010-03-15"
+        certifications: ["organic", "sustainable"]
+        fields:
+          - field_id: "550e8400-e29b-41d4-a716-446655440010"
+            name: "North Field"
+            area_hectares: 25.5
+            soil_type: "loam"
+            soil_ph: 6.8
+            coordinates:
+              - latitude: 42.1234
+                longitude: -93.5678
+              - latitude: 42.1244
+                longitude: -93.5678
+              - latitude: 42.1244
+                longitude: -93.5688
+              - latitude: 42.1234
+                longitude: -93.5688
+            slope_percentage: 2.5
+            drainage: "good"
+            current_crop_id: "550e8400-e29b-41d4-a716-446655440020"
+        irrigation_systems:
+          - system_id: "550e8400-e29b-41d4-a716-446655440030"
+            type: "drip"
+            field_ids: ["550e8400-e29b-41d4-a716-446655440010"]
+            water_source: "well"
+            flow_rate_liters_per_minute: 150.0
+            installation_date: "2015-05-10"
+            maintenance_schedule: "monthly"
+            automated: true
+        equipment:
+          - equipment_id: "550e8400-e29b-41d4-a716-446655440040"
+            name: "John Deere 7820"
+            type: "tractor"
+            manufacturer: "John Deere"
+            model: "7820"
+            year: 2018
+            purchase_date: "2018-04-15"
+            purchase_price:
+              amount: 125000.00
+              currency: "USD"
+            operating_hours: 1245.5
+            fuel_consumption_per_hour: 12.5
+            maintenance_records: []
+            status: "operational"
+    crops:
+      - crop_id: "550e8400-e29b-41d4-a716-446655440020"
+        name: "Corn"
+        variety: "Pioneer P1870"
+        category: "cereal"
+        planting_season: "spring"
+        growing_days: 110
+        water_requirements: "moderate"
+        soil_requirements: ["loam", "silt"]
+        optimal_temperature_c:
+          minimum: 18.0
+          maximum: 32.0
+        yield_per_hectare_kg: 8500.0
+        market_price_per_kg:
+          amount: 0.25
+          currency: "USD"
+    livestock:
+      - animal_id: "550e8400-e29b-41d4-a716-446655440050"
+        ear_tag: "001A"
+        species: "cattle"
+        breed: "Holstein"
+        date_of_birth: "2020-03-15"
+        gender: "female"
+        weight_kg: 550.0
+        health_status: "healthy"
+        vaccinations:
+          - vaccine_name: "IBR/BVD"
+            vaccination_date: "2024-01-15"
+            next_due_date: "2025-01-15"
+            veterinarian: "Dr. Sarah Johnson"
+            batch_number: "VB2024-001"
+        breeding_history:
+          - breeding_date: "2023-05-10"
+            mate_id: "550e8400-e29b-41d4-a716-446655440051"
+            pregnancy_confirmed: true
+            due_date: "2024-02-15"
+            birth_date: "2024-02-18"
+            offspring_count: 1
+            offspring_ids: ["550e8400-e29b-41d4-a716-446655440052"]
+        feed_consumption_kg_per_day: 25.0
+        milk_production_liters_per_day: 28.5
+        location: "Barn A"
+    field_operations:
+      - operation_id: "550e8400-e29b-41d4-a716-446655440060"
+        field_id: "550e8400-e29b-41d4-a716-446655440010"
+        operation_type: "planting"
+        crop_id: "550e8400-e29b-41d4-a716-446655440020"
+        operation_date: "2024-04-15"
+        equipment_used: ["550e8400-e29b-41d4-a716-446655440040"]
+        operator: "Mike Johnson"
+        materials_used:
+          - material_type: "seed"
+            name: "Pioneer P1870 Corn Seed"
+            quantity: 25.0
+            unit: "kg"
+            cost_per_unit:
+              amount: 8.50
+              currency: "USD"
+        weather_conditions:
+          timestamp: "2024-04-15T10:00:00Z"
+          temperature_c: 22.0
+          humidity_percent: 65.0
+          pressure_hpa: 1013.25
+          wind_speed_kmh: 8.5
+          wind_direction_degrees: 225
+          precipitation_mm: 0.0
+          visibility_km: 10.0
+          uv_index: 5
+          weather_condition: "partly_cloudy"
+        cost:
+          amount: 450.00
+          currency: "USD"
+        notes: "Good planting conditions, soil temperature optimal"
+    weather_data:
+      - timestamp: "2024-04-15T10:00:00Z"
+        temperature_c: 22.0
+        humidity_percent: 65.0
+        pressure_hpa: 1013.25
+        wind_speed_kmh: 8.5
+        wind_direction_degrees: 225
+        precipitation_mm: 0.0
+        visibility_km: 10.0
+        uv_index: 5
+        weather_condition: "partly_cloudy"
 properties:
   farms:
     type: array

--- a/tests/load/api_gateway/api_gateway.tests.yaml
+++ b/tests/load/api_gateway/api_gateway.tests.yaml
@@ -1,0 +1,254 @@
+version: 1.0.0
+tests:
+  api_gateway.yaml#/$defs/GatewayConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/TLSConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/CORSConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/TimeoutConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/SecurityConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/Route:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RouteBackend:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RetryPolicy:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/LoadBalancing:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/CircuitBreaker:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RouteAuthentication:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/JWTConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/APIKeyConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/OAuth2Config:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RouteRateLimit:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/CacheConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RequestTransformation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/ResponseTransformation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/HealthCheck:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/Middleware:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/Authentication:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/SessionConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RateLimiting:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RateLimitRule:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RateLimitStorage:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/RedisConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/Monitoring:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/MetricsConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/LoggingConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/TracingConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/JaegerConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/ZipkinConfig:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/MonitoringHealthChecks:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/HealthCheckDefinition:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/Backend:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  api_gateway.yaml#/$defs/BackendServer:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/cryptocurrency/cryptocurrency.tests.yaml
+++ b/tests/load/cryptocurrency/cryptocurrency.tests.yaml
@@ -1,0 +1,30 @@
+version: 1.0.0
+tests:
+  cryptocurrency.yaml#/$defs/User:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  cryptocurrency.yaml#/$defs/Wallet:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  cryptocurrency.yaml#/$defs/Transaction:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  cryptocurrency.yaml#/$defs/Cryptocurrency:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/ecommerce_platform/ecommerce.tests.yaml
+++ b/tests/load/ecommerce_platform/ecommerce.tests.yaml
@@ -1,0 +1,135 @@
+version: 1.0.0
+tests:
+  ecommerce.yaml#/$defs/Metadata:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Customer:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/PersonName:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Address:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/CustomerPreferences:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Product:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/ProductCategory:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Money:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Weight:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Dimensions:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/ProductImage:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/ProductVariant:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Order:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/OrderItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Payment:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/Shipping:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/OrderTotals:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/InventoryItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ecommerce.yaml#/$defs/WarehouseLocation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/education_management/education.tests.yaml
+++ b/tests/load/education_management/education.tests.yaml
@@ -1,0 +1,44 @@
+version: 1.0.0
+tests:
+  education.yaml#/$defs/Student:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  education.yaml#/$defs/Course:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  education.yaml#/$defs/Instructor:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  education.yaml#/$defs/Schedule:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  education.yaml#/$defs/Enrollment:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  education.yaml#/$defs/Grade:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/education_management/education.yaml
+++ b/tests/load/education_management/education.yaml
@@ -1,6 +1,116 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Education Management System Schema"
 type: object
+examples:
+  - students:
+      - student_id: "550e8400-e29b-41d4-a716-446655440001"
+        student_number: "20240001"
+        name:
+          first_name: "Emily"
+          middle_name: "Jane"
+          last_name: "Johnson"
+        email: "emily.johnson@university.edu"
+        date_of_birth: "2005-03-15"
+        address:
+          street: "123 Student Lane"
+          city: "University City"
+          state: "California"
+          postal_code: "90210"
+          country: "United States"
+        emergency_contact:
+          name:
+            first_name: "Robert"
+            last_name: "Johnson"
+          phone: "+15551234567"
+          relationship: "Father"
+          email: "robert.johnson@email.com"
+        enrollment_date: "2023-08-15"
+        status: "active"
+        gpa: 3.75
+    courses:
+      - course_id: "550e8400-e29b-41d4-a716-446655440010"
+        course_code: "CSC101"
+        title: "Introduction to Computer Science"
+        description: "An introductory course covering fundamental concepts of computer science including programming basics, algorithms, and data structures."
+        credits: 3
+        department: "Computer Science"
+        prerequisites: []
+        instructor:
+          instructor_id: "550e8400-e29b-41d4-a716-446655440020"
+          name:
+            first_name: "Dr. Sarah"
+            last_name: "Thompson"
+          email: "sarah.thompson@university.edu"
+          department: "Computer Science"
+          office_location: "CS Building, Room 301"
+          phone: "+15559876543"
+        schedule:
+          days: ["monday", "wednesday", "friday"]
+          start_time: "10:00"
+          end_time: "11:00"
+          room: "CS-101"
+          building: "Computer Science Building"
+        max_enrollment: 30
+        semester: "fall"
+        year: 2024
+      - course_id: "550e8400-e29b-41d4-a716-446655440011"
+        course_code: "MAT201"
+        title: "Calculus II"
+        description: "Continuation of Calculus I covering integration techniques, infinite series, and applications."
+        credits: 4
+        department: "Mathematics"
+        prerequisites: ["550e8400-e29b-41d4-a716-446655440030"]
+        instructor:
+          instructor_id: "550e8400-e29b-41d4-a716-446655440021"
+          name:
+            first_name: "Dr. Michael"
+            last_name: "Davis"
+          email: "michael.davis@university.edu"
+          department: "Mathematics"
+          office_location: "Math Building, Room 205"
+          phone: "+15559876544"
+        schedule:
+          days: ["tuesday", "thursday"]
+          start_time: "14:00"
+          end_time: "15:30"
+          room: "MATH-205"
+          building: "Mathematics Building"
+        max_enrollment: 25
+        semester: "fall"
+        year: 2024
+    enrollments:
+      - enrollment_id: "550e8400-e29b-41d4-a716-446655440040"
+        student_id: "550e8400-e29b-41d4-a716-446655440001"
+        course_id: "550e8400-e29b-41d4-a716-446655440010"
+        enrollment_date: "2024-08-20"
+        status: "enrolled"
+        final_grade: "B+"
+      - enrollment_id: "550e8400-e29b-41d4-a716-446655440041"
+        student_id: "550e8400-e29b-41d4-a716-446655440001"
+        course_id: "550e8400-e29b-41d4-a716-446655440011"
+        enrollment_date: "2024-08-20"
+        status: "enrolled"
+    grades:
+      - grade_id: "550e8400-e29b-41d4-a716-446655440050"
+        enrollment_id: "550e8400-e29b-41d4-a716-446655440040"
+        assignment_name: "Midterm Exam"
+        assignment_type: "exam"
+        points_earned: 87.5
+        points_possible: 100.0
+        percentage: 87.5
+        letter_grade: "B+"
+        graded_date: "2024-09-20"
+        comments: "Good understanding of core concepts, minor errors in algorithm implementation."
+      - grade_id: "550e8400-e29b-41d4-a716-446655440051"
+        enrollment_id: "550e8400-e29b-41d4-a716-446655440040"
+        assignment_name: "Programming Project 1"
+        assignment_type: "project"
+        points_earned: 92.0
+        points_possible: 100.0
+        percentage: 92.0
+        letter_grade: "A-"
+        graded_date: "2024-09-15"
+        comments: "Excellent code structure and documentation. Well-implemented solution."
 properties:
   students:
     type: array

--- a/tests/load/event_management/event_management.tests.yaml
+++ b/tests/load/event_management/event_management.tests.yaml
@@ -1,0 +1,58 @@
+version: 1.0.0
+tests:
+  event_management.yaml#/$defs/Event:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/Venue:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/Organizer:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/TicketType:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/Speaker:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/AgendaItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/Attendee:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  event_management.yaml#/$defs/Ticket:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/event_management/event_management.yaml
+++ b/tests/load/event_management/event_management.yaml
@@ -1,6 +1,133 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Event Management System Schema"
 type: object
+examples:
+  - events:
+      - event_id: "550e8400-e29b-41d4-a716-446655440001"
+        title: "TechConf 2024: The Future of AI"
+        description: "Join us for the premier technology conference featuring the latest innovations in artificial intelligence, machine learning, and emerging technologies. Network with industry leaders and explore cutting-edge solutions."
+        category: "conference"
+        venue_id: "550e8400-e29b-41d4-a716-446655440010"
+        organizer:
+          organizer_id: "550e8400-e29b-41d4-a716-446655440020"
+          name: "TechEvents Corp"
+          email: "events@techevents.com"
+          phone: "+15551234567"
+          organization: "TechEvents Corporation"
+          website: "https://www.techevents.com"
+        start_datetime: "2024-11-15T09:00:00Z"
+        end_datetime: "2024-11-16T18:00:00Z"
+        timezone: "America/New_York"
+        capacity: 500
+        registration_start: "2024-09-01T00:00:00Z"
+        registration_end: "2024-11-10T23:59:59Z"
+        status: "published"
+        pricing:
+          - ticket_type_id: "550e8400-e29b-41d4-a716-446655440030"
+            name: "Early Bird"
+            description: "Discounted rate for early registrations"
+            price:
+              amount: 299.00
+              currency: "USD"
+            quantity_available: 100
+            quantity_sold: 87
+            sale_start: "2024-09-01T00:00:00Z"
+            sale_end: "2024-10-15T23:59:59Z"
+            transfer_allowed: true
+            refund_allowed: true
+          - ticket_type_id: "550e8400-e29b-41d4-a716-446655440031"
+            name: "Standard"
+            description: "Regular conference pass"
+            price:
+              amount: 399.00
+              currency: "USD"
+            quantity_available: 350
+            quantity_sold: 142
+            sale_start: "2024-10-16T00:00:00Z"
+            sale_end: "2024-11-10T23:59:59Z"
+            transfer_allowed: true
+            refund_allowed: false
+        speakers:
+          - speaker_id: "550e8400-e29b-41d4-a716-446655440040"
+            name:
+              first_name: "Dr. Sarah"
+              last_name: "Chen"
+            email: "sarah.chen@airesearch.com"
+            bio: "Dr. Sarah Chen is a leading researcher in artificial intelligence with over 15 years of experience in machine learning and neural networks. She has published over 100 papers and holds 20 patents in AI technologies."
+            company: "AI Research Institute"
+            title: "Chief AI Scientist"
+            photo_url: "https://example.com/speakers/sarah-chen.jpg"
+            social_media:
+              twitter: "@sarahchen_ai"
+              linkedin: "sarahchen-ai"
+              website: "https://sarahchen.ai"
+        agenda:
+          - item_id: "550e8400-e29b-41d4-a716-446655440050"
+            title: "Opening Keynote: The Future of AI"
+            description: "An inspiring overview of where artificial intelligence is headed in the next decade"
+            start_time: "2024-11-15T09:30:00Z"
+            end_time: "2024-11-15T10:30:00Z"
+            speaker_ids: ["550e8400-e29b-41d4-a716-446655440040"]
+            location: "Main Auditorium"
+            session_type: "keynote"
+    venues:
+      - venue_id: "550e8400-e29b-41d4-a716-446655440010"
+        name: "Metropolitan Convention Center"
+        address:
+          street: "1001 Convention Plaza"
+          city: "New York"
+          state: "New York"
+          postal_code: "10001"
+          country: "United States"
+        capacity: 1000
+        venue_type: "conference_center"
+        amenities: ["wifi", "parking", "catering", "av_equipment", "accessibility", "air_conditioning", "security"]
+        contact:
+          name:
+            first_name: "Michael"
+            last_name: "Roberts"
+          phone: "+15559876543"
+          relationship: "Venue Manager"
+          email: "michael.roberts@metroconvention.com"
+        hourly_rate:
+          amount: 500.00
+          currency: "USD"
+    attendees:
+      - attendee_id: "550e8400-e29b-41d4-a716-446655440060"
+        name:
+          first_name: "John"
+          last_name: "Doe"
+        email: "john.doe@techcorp.com"
+        phone: "+15551234568"
+        company: "TechCorp Inc."
+        job_title: "Senior Software Engineer"
+        dietary_restrictions: ["vegetarian"]
+        accessibility_needs: []
+        registration_date: "2024-09-15T14:30:00Z"
+        check_in_time: "2024-11-15T08:45:00Z"
+    tickets:
+      - ticket_id: "550e8400-e29b-41d4-a716-446655440070"
+        ticket_number: "TC240001"
+        event_id: "550e8400-e29b-41d4-a716-446655440001"
+        ticket_type_id: "550e8400-e29b-41d4-a716-446655440030"
+        attendee_id: "550e8400-e29b-41d4-a716-446655440060"
+        purchase_date: "2024-09-15T14:35:00Z"
+        price_paid:
+          amount: 299.00
+          currency: "USD"
+        payment:
+          payment_id: "pay_tc240001"
+          method: "credit_card"
+          amount:
+            amount: 299.00
+            currency: "USD"
+          status: "completed"
+          transaction_date: "2024-09-15T14:35:00Z"
+          payment_provider: "stripe"
+          reference_number: "ch_3NZ8pI2eZvKYlo2C0123456789"
+        status: "used"
+        qr_code: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        used_date: "2024-11-15T08:45:00Z"
 properties:
   events:
     type: array

--- a/tests/load/financial_transactions/financial_transactions.tests.yaml
+++ b/tests/load/financial_transactions/financial_transactions.tests.yaml
@@ -1,0 +1,48 @@
+version: 1.0.0
+tests:
+  financial_transactions.yaml#/$defs/Transaction:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  financial_transactions.yaml#/$defs/Account:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  financial_transactions.yaml#/$defs/Money:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  financial_transactions.yaml#/$defs/Merchant:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  financial_transactions.yaml#/$schema:
+    valid:
+    invalid:
+  financial_transactions.yaml#/title:
+    valid:
+    invalid:
+  financial_transactions.yaml#/type:
+    valid:
+    invalid:
+  financial_transactions.yaml#/properties:
+    valid:
+    invalid:
+  financial_transactions.yaml#/examples:
+    valid:
+    invalid:
+  financial_transactions.yaml#/$defs:
+    valid:
+    invalid:

--- a/tests/load/financial_transactions/financial_transactions.yaml
+++ b/tests/load/financial_transactions/financial_transactions.yaml
@@ -10,6 +10,20 @@ properties:
     type: array
     items:
       $ref: "#/$defs/Account"
+examples:
+  - transactions:
+      - transaction_id: "550e8400-e29b-41d4-a716-446655440000"
+        account_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        amount:
+          amount: 25.99
+          currency: "USD"
+        type: "debit"
+    accounts:
+      - account_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        account_number: "1234567890"
+        balance:
+          amount: 2450.75
+          currency: "USD"
 $defs:
   Transaction:
     type: object
@@ -31,6 +45,25 @@ $defs:
       merchant:
         $ref: "#/$defs/Merchant"
     required: ["transaction_id", "account_id", "amount", "type"]
+    examples:
+      - transaction_id: "550e8400-e29b-41d4-a716-446655440000"
+        account_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        amount:
+          amount: 25.99
+          currency: "USD"
+        type: "debit"
+        timestamp: "2024-01-15T14:30:00Z"
+        merchant:
+          merchant_id: "merchant_123"
+          name: "Coffee Shop Central"
+          category: "restaurant"
+      - transaction_id: "123e4567-e89b-12d3-a456-426614174000"
+        account_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        amount:
+          amount: 1500.00
+          currency: "USD"
+        type: "credit"
+        timestamp: "2024-01-15T09:00:00Z"
   Account:
     type: object
     properties:
@@ -46,6 +79,19 @@ $defs:
         type: string
         enum: ["checking", "savings", "credit", "investment"]
     required: ["account_id", "account_number", "balance"]
+    examples:
+      - account_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        account_number: "1234567890"
+        balance:
+          amount: 2450.75
+          currency: "USD"
+        account_type: "checking"
+      - account_id: "987fcdeb-51a2-43d8-b123-456789abcdef"
+        account_number: "9876543210"
+        balance:
+          amount: 15000.00
+          currency: "EUR"
+        account_type: "savings"
   Money:
     type: object
     properties:
@@ -56,6 +102,13 @@ $defs:
         type: string
         pattern: "^[A-Z]{3}$"
     required: ["amount", "currency"]
+    examples:
+      - amount: 25.99
+        currency: "USD"
+      - amount: 1000.00
+        currency: "EUR"
+      - amount: 500.75
+        currency: "GBP"
   Merchant:
     type: object
     properties:
@@ -67,3 +120,13 @@ $defs:
         type: string
         enum: ["retail", "restaurant", "gas", "grocery", "online"]
     required: ["merchant_id", "name"]
+    examples:
+      - merchant_id: "merchant_123"
+        name: "Coffee Shop Central"
+        category: "restaurant"
+      - merchant_id: "merchant_456"
+        name: "Amazon.com"
+        category: "online"
+      - merchant_id: "merchant_789"
+        name: "Shell Gas Station"
+        category: "gas"

--- a/tests/load/fitness_tracking/fitness_tracking.tests.yaml
+++ b/tests/load/fitness_tracking/fitness_tracking.tests.yaml
@@ -1,0 +1,51 @@
+version: 1.0.0
+tests:
+  fitness_tracking.yaml#/$defs/User:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fitness_tracking.yaml#/$defs/Workout:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fitness_tracking.yaml#/$defs/Exercise:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fitness_tracking.yaml#/$defs/WorkoutExercise:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fitness_tracking.yaml#/$defs/ExerciseSet:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fitness_tracking.yaml#/$defs/NutritionEntry:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fitness_tracking.yaml#/$defs/FoodItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/fitness_tracking/fitness_tracking.yaml
+++ b/tests/load/fitness_tracking/fitness_tracking.yaml
@@ -1,6 +1,92 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Fitness Tracking Application Schema"
 type: object
+examples:
+  - users:
+      - user_id: "550e8400-e29b-41d4-a716-446655440001"
+        name:
+          first_name: "Alex"
+          last_name: "Johnson"
+        email: "alex.johnson@email.com"
+        date_of_birth: "1990-05-15"
+        gender: "other"
+        height_cm: 175.0
+        weight_kg: 72.5
+        activity_level: "moderately_active"
+        goals: ["weight_loss", "endurance"]
+        target_weight_kg: 68.0
+        created_at: "2024-01-15T10:30:00Z"
+    workouts:
+      - workout_id: "550e8400-e29b-41d4-a716-446655440010"
+        user_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Upper Body Strength"
+        date: "2024-10-01"
+        start_time: "2024-10-01T18:00:00Z"
+        end_time: "2024-10-01T19:15:00Z"
+        workout_type: "strength"
+        exercises:
+          - exercise_id: "550e8400-e29b-41d4-a716-446655440020"
+            sets:
+              - set_number: 1
+                reps: 12
+                weight_kg: 60.0
+                completed: true
+              - set_number: 2
+                reps: 10
+                weight_kg: 65.0
+                completed: true
+              - set_number: 3
+                reps: 8
+                weight_kg: 70.0
+                completed: true
+            rest_time_seconds: 90
+            notes: "Felt strong today"
+        total_calories_burned: 285
+        notes: "Great workout, increased weight on bench press"
+        rating: 4
+    exercises:
+      - exercise_id: "550e8400-e29b-41d4-a716-446655440020"
+        name: "Bench Press"
+        category: "chest"
+        muscle_groups: ["chest", "triceps", "shoulders"]
+        equipment: ["barbell"]
+        difficulty: "intermediate"
+        instructions: "Lie on bench, lower bar to chest, press up with control. Keep feet planted and core engaged."
+        tips: "Grip bar slightly wider than shoulders. Don't bounce the bar off your chest."
+    nutrition:
+      - entry_id: "550e8400-e29b-41d4-a716-446655440030"
+        user_id: "550e8400-e29b-41d4-a716-446655440001"
+        date: "2024-10-01"
+        meal_type: "breakfast"
+        foods:
+          - food_id: "550e8400-e29b-41d4-a716-446655440040"
+            name: "Greek Yogurt"
+            brand: "Chobani"
+            serving_size: "1 cup (227g)"
+            quantity: 1.0
+            calories_per_serving: 130
+            protein_g: 20.0
+            carbs_g: 9.0
+            fat_g: 0.0
+            fiber_g: 0.0
+            sugar_g: 6.0
+          - food_id: "550e8400-e29b-41d4-a716-446655440041"
+            name: "Blueberries"
+            brand: "Fresh"
+            serving_size: "1/2 cup (74g)"
+            quantity: 1.0
+            calories_per_serving: 42
+            protein_g: 0.5
+            carbs_g: 10.7
+            fat_g: 0.2
+            fiber_g: 1.8
+            sugar_g: 7.2
+        total_calories: 172
+        total_protein_g: 20.5
+        total_carbs_g: 19.7
+        total_fat_g: 0.2
+        total_fiber_g: 1.8
+        total_sugar_g: 13.2
 properties:
   users:
     type: array

--- a/tests/load/fleet_management/fleet_management.tests.yaml
+++ b/tests/load/fleet_management/fleet_management.tests.yaml
@@ -1,0 +1,51 @@
+version: 1.0.0
+tests:
+  fleet_management.yaml#/$defs/Vehicle:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fleet_management.yaml#/$defs/Driver:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fleet_management.yaml#/$defs/DriversLicense:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fleet_management.yaml#/$defs/Route:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fleet_management.yaml#/$defs/MaintenanceRecord:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fleet_management.yaml#/$defs/Part:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  fleet_management.yaml#/$defs/Insurance:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/fleet_management/fleet_management.yaml
+++ b/tests/load/fleet_management/fleet_management.yaml
@@ -1,6 +1,127 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Fleet Management System Schema"
 type: object
+examples:
+  - vehicles:
+      - vehicle_id: "550e8400-e29b-41d4-a716-446655440001"
+        license_plate: "ABC-1234"
+        vin: "1HGBH41JXMN109186"
+        make: "Ford"
+        model: "Transit"
+        year: 2023
+        vehicle_type: "van"
+        fuel_type: "gasoline"
+        mileage: 45820
+        location:
+          address: "123 Fleet Street"
+          city: "San Francisco"
+          state: "CA"
+          postal_code: "94105"
+          country: "United States"
+          latitude: 37.7749
+          longitude: -122.4194
+        status: "available"
+        assigned_driver_id: "550e8400-e29b-41d4-a716-446655440010"
+        insurance:
+          policy_number: "POL-FL-2024-001"
+          provider: "Fleet Insurance Corp"
+          coverage_type: "comprehensive"
+          premium:
+            amount: 1200.00
+            currency: "USD"
+          deductible:
+            amount: 500.00
+            currency: "USD"
+          effective_date: "2024-01-01"
+          expiration_date: "2024-12-31"
+    drivers:
+      - driver_id: "550e8400-e29b-41d4-a716-446655440010"
+        employee_id: "EMP-2024-001"
+        name:
+          first_name: "Maria"
+          last_name: "Rodriguez"
+        email: "maria.rodriguez@fleetco.com"
+        phone: "+15551234567"
+        address:
+          street: "456 Driver Lane"
+          city: "Oakland"
+          state: "California"
+          postal_code: "94607"
+          country: "United States"
+        license:
+          license_number: "D1234567"
+          license_class: "B"
+          issue_date: "2020-03-15"
+          expiration_date: "2028-03-15"
+          issuing_state: "CA"
+          restrictions: []
+        hire_date: "2022-06-01"
+        status: "active"
+        certifications: ["Defensive Driving", "Commercial Vehicle Safety"]
+    routes:
+      - route_id: "550e8400-e29b-41d4-a716-446655440020"
+        name: "Downtown Delivery Route"
+        vehicle_id: "550e8400-e29b-41d4-a716-446655440001"
+        driver_id: "550e8400-e29b-41d4-a716-446655440010"
+        start_location:
+          address: "123 Fleet Street"
+          city: "San Francisco"
+          state: "CA"
+          postal_code: "94105"
+          country: "United States"
+          latitude: 37.7749
+          longitude: -122.4194
+        end_location:
+          address: "789 Customer Ave"
+          city: "San Francisco"
+          state: "CA"
+          postal_code: "94102"
+          country: "United States"
+          latitude: 37.7849
+          longitude: -122.4094
+        waypoints:
+          - address: "456 Waypoint St"
+            city: "San Francisco"
+            state: "CA"
+            postal_code: "94103"
+            country: "United States"
+            latitude: 37.7799
+            longitude: -122.4144
+        estimated_duration_minutes: 45
+        estimated_distance_miles: 12.5
+        scheduled_start: "2024-10-01T09:00:00Z"
+        actual_start: "2024-10-01T09:05:00Z"
+        actual_end: "2024-10-01T09:52:00Z"
+        status: "completed"
+    maintenance:
+      - maintenance_id: "550e8400-e29b-41d4-a716-446655440030"
+        vehicle_id: "550e8400-e29b-41d4-a716-446655440001"
+        maintenance_type: "routine"
+        description: "Regular oil change and 20-point inspection"
+        scheduled_date: "2024-09-15"
+        completed_date: "2024-09-15"
+        cost:
+          amount: 89.95
+          currency: "USD"
+        service_provider: "Quick Lube Express"
+        mileage_at_service: 45000
+        next_service_due: "2024-12-15"
+        status: "completed"
+        parts_replaced:
+          - part_number: "OF-5W30-5QT"
+            description: "5W-30 Motor Oil, 5 Quarts"
+            quantity: 1
+            cost_per_unit:
+              amount: 24.99
+              currency: "USD"
+            supplier: "AutoParts Plus"
+          - part_number: "OF-FILTER-A123"
+            description: "Oil Filter"
+            quantity: 1
+            cost_per_unit:
+              amount: 12.99
+              currency: "USD"
+            supplier: "AutoParts Plus"
 properties:
   vehicles:
     type: array

--- a/tests/load/gaming_platform/gaming.tests.yaml
+++ b/tests/load/gaming_platform/gaming.tests.yaml
@@ -1,0 +1,79 @@
+version: 1.0.0
+tests:
+  gaming.yaml#/$defs/Player:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/PlayerProfile:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/PrivacySettings:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/PlayerStats:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/Game:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/Map:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/Match:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/MatchPlayer:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/Team:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/Tournament:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  gaming.yaml#/$defs/Achievement:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/gaming_platform/gaming.yaml
+++ b/tests/load/gaming_platform/gaming.yaml
@@ -1,6 +1,106 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Gaming Platform Schema"
 type: object
+examples:
+  - players:
+      - player_id: "550e8400-e29b-41d4-a716-446655440001"
+        username: "shadow_gamer123"
+        email: "alex.shadow@email.com"
+        profile:
+          display_name: "Shadow Gamer"
+          avatar_url: "https://cdn.gaming.com/avatars/shadow_gamer.png"
+          country: "US"
+          preferred_language: "en"
+          bio: "Competitive FPS player, always looking for new challenges!"
+          privacy_settings:
+            profile_visible: true
+            stats_visible: true
+            online_status_visible: false
+            allow_friend_requests: true
+        stats:
+          total_games_played: 1247
+          total_wins: 823
+          total_losses: 424
+          win_rate: 0.66
+          ranking: 1584
+          skill_level: "gold"
+          total_playtime_hours: 342.5
+        achievements:
+          - achievement_id: "550e8400-e29b-41d4-a716-446655440050"
+            name: "First Victory"
+            description: "Win your first match"
+            category: "milestone"
+            rarity: "common"
+            icon_url: "https://cdn.gaming.com/achievements/first_victory.png"
+            unlocked_at: "2024-01-15T14:30:00Z"
+            progress:
+              current: 1
+              required: 1
+        created_at: "2024-01-15T10:00:00Z"
+        last_active: "2024-10-01T09:45:00Z"
+    games:
+      - game_id: "550e8400-e29b-41d4-a716-446655440010"
+        title: "Tactical Strike"
+        genre: "fps"
+        max_players: 10
+        min_players: 2
+        game_modes: ["Team Deathmatch", "Capture the Flag", "Search and Destroy"]
+        maps:
+          - map_id: "550e8400-e29b-41d4-a716-446655440020"
+            name: "Industrial Complex"
+            description: "Urban warfare in an abandoned factory setting"
+            game_modes: ["Team Deathmatch", "Search and Destroy"]
+            size: "medium"
+            environment: "urban"
+        version: "2.1.3"
+        release_date: "2023-03-15"
+    matches:
+      - match_id: "550e8400-e29b-41d4-a716-446655440030"
+        game_id: "550e8400-e29b-41d4-a716-446655440010"
+        game_mode: "Team Deathmatch"
+        map_id: "550e8400-e29b-41d4-a716-446655440020"
+        players:
+          - player_id: "550e8400-e29b-41d4-a716-446655440001"
+            team_id: "550e8400-e29b-41d4-a716-446655440040"
+            character: "Assault Specialist"
+            score: 1850
+            kills: 15
+            deaths: 8
+            assists: 6
+            joined_at: "2024-10-01T20:00:00Z"
+            left_at: "2024-10-01T20:18:00Z"
+        teams:
+          - team_id: "550e8400-e29b-41d4-a716-446655440040"
+            name: "Alpha Team"
+            color: "blue"
+            score: 75
+            player_ids: ["550e8400-e29b-41d4-a716-446655440001"]
+          - team_id: "550e8400-e29b-41d4-a716-446655440041"
+            name: "Bravo Team"
+            color: "red"
+            score: 62
+            player_ids: []
+        start_time: "2024-10-01T20:00:00Z"
+        end_time: "2024-10-01T20:18:00Z"
+        duration_seconds: 1080
+        status: "completed"
+        winner: "550e8400-e29b-41d4-a716-446655440040"
+    tournaments:
+      - tournament_id: "550e8400-e29b-41d4-a716-446655440060"
+        name: "Autumn Championship 2024"
+        game_id: "550e8400-e29b-41d4-a716-446655440010"
+        format: "single_elimination"
+        max_participants: 64
+        prize_pool:
+          amount: 10000.00
+          currency: "USD"
+        registration_start: "2024-09-01T00:00:00Z"
+        registration_end: "2024-09-30T23:59:59Z"
+        start_date: "2024-10-15T18:00:00Z"
+        end_date: "2024-10-20T22:00:00Z"
+        status: "registration_open"
+        participants: ["550e8400-e29b-41d4-a716-446655440001"]
+        matches: []
 properties:
   players:
     type: array

--- a/tests/load/healthcare_records/healthcare_records.tests.yaml
+++ b/tests/load/healthcare_records/healthcare_records.tests.yaml
@@ -1,0 +1,44 @@
+version: 1.0.0
+tests:
+  healthcare_records.yaml#/$defs/Patient:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  healthcare_records.yaml#/$defs/MedicalRecord:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  healthcare_records.yaml#/$defs/EmergencyContact:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  healthcare_records.yaml#/$defs/Diagnosis:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  healthcare_records.yaml#/$defs/Medication:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  healthcare_records.yaml#/$defs/VitalSigns:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/healthcare_records/healthcare_records.yaml
+++ b/tests/load/healthcare_records/healthcare_records.yaml
@@ -1,6 +1,52 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Healthcare Records Schema"
 type: object
+examples:
+  - patients:
+      - patient_id: "550e8400-e29b-41d4-a716-446655440001"
+        name:
+          first_name: "Sarah"
+          middle_name: "Elizabeth"
+          last_name: "Miller"
+        date_of_birth: "1985-07-20"
+        gender: "female"
+        blood_type: "A+"
+        allergies: ["Penicillin", "Shellfish", "Latex"]
+        emergency_contact:
+          name:
+            first_name: "Michael"
+            last_name: "Miller"
+          relationship: "Spouse"
+          phone: "+15551234567"
+          email: "michael.miller@email.com"
+    medical_records:
+      - record_id: "550e8400-e29b-41d4-a716-446655440010"
+        patient_id: "550e8400-e29b-41d4-a716-446655440001"
+        visit_date: "2024-09-15"
+        diagnosis:
+          - code: "Z00.0"
+            description: "Encounter for general adult medical examination without abnormal findings"
+            severity: "mild"
+          - code: "E11.9"
+            description: "Type 2 diabetes mellitus without complications"
+            severity: "moderate"
+        medications:
+          - name: "Metformin"
+            dosage: "500mg"
+            frequency: "Twice daily with meals"
+            start_date: "2024-09-15"
+            end_date: "2025-09-15"
+          - name: "Lisinopril"
+            dosage: "10mg"
+            frequency: "Once daily"
+            start_date: "2024-09-15"
+        vitals:
+          temperature: 36.8
+          blood_pressure:
+            systolic: 128
+            diastolic: 82
+          heart_rate: 72
+          weight: 68.5
 properties:
   patients:
     type: array

--- a/tests/load/hotel_booking/hotel_booking.tests.yaml
+++ b/tests/load/hotel_booking/hotel_booking.tests.yaml
@@ -1,0 +1,37 @@
+version: 1.0.0
+tests:
+  hotel_booking.yaml#/$defs/Hotel:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  hotel_booking.yaml#/$defs/Room:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  hotel_booking.yaml#/$defs/Booking:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  hotel_booking.yaml#/$defs/Guest:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  hotel_booking.yaml#/$defs/GuestPreferences:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/hotel_booking/hotel_booking.yaml
+++ b/tests/load/hotel_booking/hotel_booking.yaml
@@ -1,6 +1,88 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Hotel Booking Management Schema"
 type: object
+examples:
+  - hotels:
+      - hotel_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Grand Pacific Resort"
+        address:
+          street: "1500 Ocean Boulevard"
+          city: "Miami Beach"
+          state: "Florida"
+          postal_code: "33139"
+          country: "United States"
+        star_rating: 5
+        amenities: ["wifi", "pool", "gym", "spa", "restaurant", "bar", "parking", "concierge"]
+        rooms:
+          - room_id: "550e8400-e29b-41d4-a716-446655440010"
+            room_number: "1205"
+            room_type: "deluxe"
+            capacity: 2
+            price_per_night:
+              amount: 450.00
+              currency: "USD"
+            amenities: ["Ocean view", "King bed", "Balcony", "Mini bar", "Coffee machine"]
+            available: true
+          - room_id: "550e8400-e29b-41d4-a716-446655440011"
+            room_number: "2010"
+            room_type: "suite"
+            capacity: 4
+            price_per_night:
+              amount: 850.00
+              currency: "USD"
+            amenities: ["Ocean view", "Separate living room", "Kitchen", "Jacuzzi", "Butler service"]
+            available: true
+        contact:
+          name:
+            first_name: "Isabella"
+            last_name: "Rodriguez"
+          relationship: "Hotel Manager"
+          phone: "+13055551234"
+          email: "manager@grandpacific.com"
+    bookings:
+      - booking_id: "550e8400-e29b-41d4-a716-446655440020"
+        confirmation_number: "GPR001"
+        hotel_id: "550e8400-e29b-41d4-a716-446655440001"
+        room_id: "550e8400-e29b-41d4-a716-446655440010"
+        guest_id: "550e8400-e29b-41d4-a716-446655440030"
+        check_in_date: "2024-12-20"
+        check_out_date: "2024-12-23"
+        nights: 3
+        total_amount:
+          amount: 1350.00
+          currency: "USD"
+        payment:
+          payment_id: "pay_gpr001"
+          method: "credit_card"
+          amount:
+            amount: 1350.00
+            currency: "USD"
+          status: "completed"
+          transaction_date: "2024-10-01T15:30:00Z"
+          payment_provider: "stripe"
+          reference_number: "ch_3NZ8pI2eZvKYlo2C0987654321"
+        status: "confirmed"
+        special_requests: "Late check-in requested, ocean view preferred, anniversary celebration - please prepare room with flowers and champagne"
+    guests:
+      - guest_id: "550e8400-e29b-41d4-a716-446655440030"
+        name:
+          first_name: "David"
+          last_name: "Anderson"
+        email: "david.anderson@email.com"
+        phone: "+12125559876"
+        address:
+          street: "789 Manhattan Avenue"
+          city: "New York"
+          state: "New York"
+          postal_code: "10025"
+          country: "United States"
+        loyalty_number: "GPR-GOLD-123456"
+        preferences:
+          room_type: "deluxe"
+          floor_preference: "high"
+          bed_type: "king"
+          smoking: false
+          dietary_restrictions: ["Vegetarian", "Gluten-free"]
 properties:
   hotels:
     type: array

--- a/tests/load/insurance_claims/insurance_claims.tests.yaml
+++ b/tests/load/insurance_claims/insurance_claims.tests.yaml
@@ -1,0 +1,65 @@
+version: 1.0.0
+tests:
+  insurance_claims.yaml#/$defs/Policyholder:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/Policy:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/CoveredItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/VehicleDetails:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/PropertyDetails:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/Claim:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/ClaimDocument:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/ClaimEvent:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  insurance_claims.yaml#/$defs/Adjuster:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/insurance_claims/insurance_claims.yaml
+++ b/tests/load/insurance_claims/insurance_claims.yaml
@@ -1,6 +1,126 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Insurance Claims Management Schema"
 type: object
+examples:
+  - policies:
+      - policy_id: "550e8400-e29b-41d4-a716-446655440001"
+        policy_number: "POL-12345678"
+        policyholder_id: "550e8400-e29b-41d4-a716-446655440010"
+        policy_type: "auto"
+        coverage_type: "comprehensive"
+        premium:
+          amount: 1200.00
+          currency: "USD"
+        deductible:
+          amount: 500.00
+          currency: "USD"
+        coverage_limit:
+          amount: 100000.00
+          currency: "USD"
+        effective_date: "2024-01-01"
+        expiration_date: "2024-12-31"
+        status: "active"
+        covered_items:
+          - item_id: "550e8400-e29b-41d4-a716-446655440020"
+            item_type: "vehicle"
+            description: "2022 Honda Civic Sedan"
+            value:
+              amount: 25000.00
+              currency: "USD"
+            details:
+              make: "Honda"
+              model: "Civic"
+              year: 2022
+              vin: "1HGBH41JXMN109186"
+              license_plate: "ABC-1234"
+    claims:
+      - claim_id: "550e8400-e29b-41d4-a716-446655440030"
+        claim_number: "CLM-87654321"
+        policy_id: "550e8400-e29b-41d4-a716-446655440001"
+        incident_date: "2024-09-25"
+        reported_date: "2024-09-26"
+        claim_type: "accident"
+        description: "Rear-end collision at intersection of Main St and Oak Ave. Other driver ran red light and struck insured vehicle from behind. Moderate damage to rear bumper and trunk area. No injuries reported."
+        location:
+          address: "Main St & Oak Ave"
+          city: "Springfield"
+          state: "IL"
+          postal_code: "62701"
+          country: "United States"
+          latitude: 39.7817
+          longitude: -89.6501
+        estimated_loss:
+          amount: 4500.00
+          currency: "USD"
+        claimed_amount:
+          amount: 4200.00
+          currency: "USD"
+        approved_amount:
+          amount: 3800.00
+          currency: "USD"
+        status: "approved"
+        adjuster_id: "550e8400-e29b-41d4-a716-446655440040"
+        documents:
+          - document_id: "550e8400-e29b-41d4-a716-446655440050"
+            document_type: "police_report"
+            file_name: "police_report_20240925.pdf"
+            file_url: "https://claims.insureco.com/docs/police_report_20240925.pdf"
+            uploaded_date: "2024-09-26T14:30:00Z"
+            uploaded_by: "John Smith (Policyholder)"
+          - document_id: "550e8400-e29b-41d4-a716-446655440051"
+            document_type: "photo"
+            file_name: "vehicle_damage_rear.jpg"
+            file_url: "https://claims.insureco.com/docs/vehicle_damage_rear.jpg"
+            uploaded_date: "2024-09-26T15:45:00Z"
+            uploaded_by: "John Smith (Policyholder)"
+        timeline:
+          - event_id: "550e8400-e29b-41d4-a716-446655440060"
+            event_type: "submitted"
+            date: "2024-09-26T10:15:00Z"
+            user: "John Smith"
+            notes: "Initial claim submission via mobile app"
+          - event_id: "550e8400-e29b-41d4-a716-446655440061"
+            event_type: "assigned"
+            date: "2024-09-26T11:30:00Z"
+            user: "System"
+            notes: "Automatically assigned to adjuster based on location and claim type"
+          - event_id: "550e8400-e29b-41d4-a716-446655440062"
+            event_type: "approved"
+            date: "2024-09-28T16:20:00Z"
+            user: "Jane Doe (Adjuster)"
+            notes: "Claim approved after review of documentation and inspection"
+    policyholders:
+      - policyholder_id: "550e8400-e29b-41d4-a716-446655440010"
+        name:
+          first_name: "John"
+          middle_name: "Michael"
+          last_name: "Smith"
+        email: "john.smith@email.com"
+        phone: "+15551234567"
+        address:
+          street: "123 Elm Street"
+          city: "Springfield"
+          state: "Illinois"
+          postal_code: "62701"
+          country: "United States"
+        date_of_birth: "1980-04-15"
+        ssn: "123-45-6789"
+        driver_license: "S123456789012"
+        credit_score: 742
+    adjusters:
+      - adjuster_id: "550e8400-e29b-41d4-a716-446655440040"
+        name:
+          first_name: "Jane"
+          last_name: "Doe"
+        email: "jane.doe@insureco.com"
+        phone: "+15559876543"
+        license_number: "ADJ-IL-123456"
+        specialties: ["auto", "property"]
+        hire_date: "2020-03-01"
+        active_caseload: 23
+        max_authority:
+          amount: 25000.00
+          currency: "USD"
 properties:
   policies:
     type: array

--- a/tests/load/iot_sensors/iot_sensors.tests.yaml
+++ b/tests/load/iot_sensors/iot_sensors.tests.yaml
@@ -1,0 +1,16 @@
+version: 1.0.0
+tests:
+  iot_sensors.yaml#/$defs/Device:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  iot_sensors.yaml#/$defs/SensorReading:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/iot_sensors/iot_sensors.yaml
+++ b/tests/load/iot_sensors/iot_sensors.yaml
@@ -10,6 +10,15 @@ properties:
     type: array
     items:
       $ref: "#/$defs/SensorReading"
+examples:
+  - devices:
+      - device_id: "550e8400-e29b-41d4-a716-446655440000"
+        device_type: "temperature"
+    readings:
+      - reading_id: "123e4567-e89b-12d3-a456-426614174000"
+        device_id: "550e8400-e29b-41d4-a716-446655440000"
+        timestamp: "2024-01-15T10:30:00Z"
+        value: 23.5
 $defs:
   Device:
     type: object
@@ -29,6 +38,14 @@ $defs:
             type: number
         required: ["latitude", "longitude"]
     required: ["device_id", "device_type"]
+    examples:
+      - device_id: "550e8400-e29b-41d4-a716-446655440000"
+        device_type: "temperature"
+        location:
+          latitude: 37.7749
+          longitude: -122.4194
+      - device_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        device_type: "motion"
   SensorReading:
     type: object
     properties:
@@ -46,3 +63,14 @@ $defs:
       unit:
         type: string
     required: ["reading_id", "device_id", "timestamp", "value"]
+    examples:
+      - reading_id: "123e4567-e89b-12d3-a456-426614174000"
+        device_id: "550e8400-e29b-41d4-a716-446655440000"
+        timestamp: "2024-01-15T10:30:00Z"
+        value: 23.5
+        unit: "°C"
+      - reading_id: "987fcdeb-51a2-43d8-b123-456789abcdef"
+        device_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        timestamp: "2024-01-15T10:31:00Z"
+        value: 1013.25
+        unit: "hPa"

--- a/tests/load/job_board/job_board.tests.yaml
+++ b/tests/load/job_board/job_board.tests.yaml
@@ -1,0 +1,72 @@
+version: 1.0.0
+tests:
+  job_board.yaml#/$defs/Job:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/Company:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/Candidate:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/WorkExperience:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/Education:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/Certification:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/Application:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/CustomResponse:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/SalaryRange:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  job_board.yaml#/$defs/JobOffer:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/job_board/job_board.yaml
+++ b/tests/load/job_board/job_board.yaml
@@ -1,6 +1,111 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Job Board Platform Schema"
 type: object
+examples:
+  - jobs:
+      - job_id: "550e8400-e29b-41d4-a716-446655440001"
+        title: "Senior Full Stack Developer"
+        description: "We are seeking an experienced Full Stack Developer to join our growing engineering team. You will work on cutting-edge web applications using modern technologies including React, Node.js, and cloud infrastructure. This role offers the opportunity to work on challenging projects that impact millions of users worldwide."
+        company_id: "550e8400-e29b-41d4-a716-446655440010"
+        department: "Engineering"
+        location:
+          street: "1 Hacker Way"
+          city: "Menlo Park"
+          state: "California"
+          postal_code: "94025"
+          country: "United States"
+        remote_work: "hybrid"
+        employment_type: "full_time"
+        experience_level: "senior"
+        salary_range:
+          min_salary:
+            amount: 120000.00
+            currency: "USD"
+          max_salary:
+            amount: 180000.00
+            currency: "USD"
+          salary_type: "annual"
+        required_skills: ["JavaScript", "React", "Node.js", "PostgreSQL", "AWS"]
+        preferred_skills: ["TypeScript", "Docker", "Kubernetes", "GraphQL", "CI/CD"]
+        education_requirements: "bachelors"
+        benefits: ["health_insurance", "dental", "vision", "401k", "pto", "flexible_hours", "remote_work"]
+        posted_date: "2024-09-15T10:00:00Z"
+        application_deadline: "2024-11-15"
+        status: "open"
+        application_count: 47
+    companies:
+      - company_id: "550e8400-e29b-41d4-a716-446655440010"
+        name: "TechVision Inc."
+        description: "A leading technology company focused on building innovative web and mobile applications that transform how people interact with technology."
+        industry: "Technology"
+        size: "201-500"
+        founded_year: 2015
+        website: "https://techvision.com"
+        headquarters:
+          street: "1 Hacker Way"
+          city: "Menlo Park"
+          state: "California"
+          postal_code: "94025"
+          country: "United States"
+        logo_url: "https://techvision.com/logo.png"
+        culture: ["Innovation", "Work-life balance", "Remote-friendly", "Continuous learning"]
+        benefits: ["health_insurance", "dental", "vision", "401k", "pto", "flexible_hours", "remote_work", "gym_membership"]
+    candidates:
+      - candidate_id: "550e8400-e29b-41d4-a716-446655440020"
+        name:
+          first_name: "Sarah"
+          last_name: "Chen"
+        email: "sarah.chen@email.com"
+        phone: "+14155559876"
+        address:
+          street: "456 Developer Street"
+          city: "San Francisco"
+          state: "California"
+          postal_code: "94102"
+          country: "United States"
+        profile:
+          headline: "Senior Full Stack Developer with 8+ years experience"
+          summary: "Passionate full stack developer with expertise in modern web technologies. Experienced in building scalable applications from conception to deployment."
+          skills: ["JavaScript", "React", "Node.js", "Python", "PostgreSQL", "AWS", "Docker"]
+          experience_years: 8
+          desired_salary:
+            amount: 150000.00
+            currency: "USD"
+          willing_to_relocate: false
+          remote_work_preference: "hybrid"
+        work_experience:
+          - company: "Previous Tech Co"
+            title: "Full Stack Developer"
+            start_date: "2020-01-15"
+            end_date: "2024-08-30"
+            description: "Led development of customer-facing web applications serving 100K+ users"
+        education:
+          - institution: "University of California, Berkeley"
+            degree: "Bachelor of Science in Computer Science"
+            graduation_date: "2016-05-15"
+            gpa: 3.7
+        resume_url: "https://candidates.jobboard.com/resumes/sarah_chen_resume.pdf"
+        created_at: "2024-09-10T14:30:00Z"
+        last_active: "2024-10-01T09:15:00Z"
+    applications:
+      - application_id: "550e8400-e29b-41d4-a716-446655440030"
+        job_id: "550e8400-e29b-41d4-a716-446655440001"
+        candidate_id: "550e8400-e29b-41d4-a716-446655440020"
+        applied_date: "2024-09-20T11:45:00Z"
+        status: "under_review"
+        cover_letter: "I am excited to apply for the Senior Full Stack Developer position at TechVision Inc. With my 8 years of experience building scalable web applications and my expertise in the required technologies, I believe I would be a great addition to your engineering team."
+        custom_responses:
+          - question: "What interests you most about this role?"
+            answer: "The opportunity to work on challenging projects that impact millions of users and to contribute to innovative solutions in a fast-paced environment."
+        interview_rounds:
+          - round_id: "550e8400-e29b-41d4-a716-446655440040"
+            round_type: "phone_screen"
+            scheduled_date: "2024-10-05T14:00:00Z"
+            duration_minutes: 30
+            interviewer: "John Smith"
+            status: "scheduled"
+            notes: "Initial phone screening to discuss background and basic technical concepts"
+        notes: "Strong technical background, good communication skills, available to start within 2 weeks"
 properties:
   jobs:
     type: array

--- a/tests/load/library_system/library_system.tests.yaml
+++ b/tests/load/library_system/library_system.tests.yaml
@@ -1,0 +1,44 @@
+version: 1.0.0
+tests:
+  library_system.yaml#/$defs/Book:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  library_system.yaml#/$defs/Author:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  library_system.yaml#/$defs/ShelfLocation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  library_system.yaml#/$defs/Member:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  library_system.yaml#/$defs/Loan:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  library_system.yaml#/$defs/Reservation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/library_system/library_system.yaml
+++ b/tests/load/library_system/library_system.yaml
@@ -1,6 +1,85 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Library Management System Schema"
 type: object
+examples:
+  - books:
+      - book_id: "550e8400-e29b-41d4-a716-446655440001"
+        isbn: "978-0-7475-3269-9"
+        title: "Harry Potter and the Philosopher's Stone"
+        subtitle: "The Boy Who Lived"
+        authors:
+          - author_id: "550e8400-e29b-41d4-a716-446655440010"
+            name:
+              first_name: "J.K."
+              last_name: "Rowling"
+            birth_date: "1965-07-31"
+            nationality: "GB"
+            biography: "British author and philanthropist best known for writing the Harry Potter fantasy series."
+        publisher: "Bloomsbury Publishing"
+        publication_date: "1997-06-26"
+        edition: "First Edition"
+        language: "en"
+        pages: 223
+        genre: "children"
+        dewey_decimal: "823.914"
+        location:
+          floor: 2
+          section: "CF"
+          aisle: "A3"
+          shelf: "H15"
+        condition: "good"
+        status: "available"
+        copies_total: 5
+        copies_available: 3
+    members:
+      - member_id: "550e8400-e29b-41d4-a716-446655440020"
+        card_number: "1234567890"
+        name:
+          first_name: "Emma"
+          last_name: "Watson"
+        email: "emma.watson@email.com"
+        phone: "+15551234567"
+        address:
+          street: "123 Library Lane"
+          city: "Boston"
+          state: "Massachusetts"
+          postal_code: "02101"
+          country: "United States"
+        date_of_birth: "1995-04-15"
+        membership_type: "adult"
+        registration_date: "2020-01-15"
+        expiration_date: "2025-01-15"
+        status: "active"
+        fines_owed:
+          amount: 0.00
+          currency: "USD"
+        borrowing_limit: 10
+        preferences:
+          preferred_genres: ["fiction", "young_adult", "science"]
+          notification_method: "email"
+          language: "en"
+    loans:
+      - loan_id: "550e8400-e29b-41d4-a716-446655440030"
+        book_id: "550e8400-e29b-41d4-a716-446655440001"
+        member_id: "550e8400-e29b-41d4-a716-446655440020"
+        checkout_date: "2024-09-15"
+        due_date: "2024-10-15"
+        return_date: "2024-10-12"
+        renewal_count: 0
+        status: "returned"
+        late_fees:
+          amount: 0.00
+          currency: "USD"
+        notes: "Book returned in excellent condition"
+    reservations:
+      - reservation_id: "550e8400-e29b-41d4-a716-446655440040"
+        book_id: "550e8400-e29b-41d4-a716-446655440001"
+        member_id: "550e8400-e29b-41d4-a716-446655440020"
+        reservation_date: "2024-10-01"
+        expiration_date: "2024-10-08"
+        status: "active"
+        position_in_queue: 1
+        notification_sent: true
 properties:
   books:
     type: array

--- a/tests/load/logistics_shipping/logistics.tests.yaml
+++ b/tests/load/logistics_shipping/logistics.tests.yaml
@@ -1,0 +1,37 @@
+version: 1.0.0
+tests:
+  logistics.yaml#/$defs/Shipment:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  logistics.yaml#/$defs/Package:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  logistics.yaml#/$defs/PackageItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  logistics.yaml#/$defs/Vehicle:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  logistics.yaml#/$defs/Location:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/logistics_shipping/logistics.yaml
+++ b/tests/load/logistics_shipping/logistics.yaml
@@ -1,6 +1,102 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Logistics and Shipping Schema"
 type: object
+examples:
+  - shipments:
+      - shipment_id: "550e8400-e29b-41d4-a716-446655440001"
+        tracking_number: "1Z999AA1012345675"
+        origin:
+          address:
+            street: "123 Warehouse Drive"
+            city: "Los Angeles"
+            state: "California"
+            postal_code: "90210"
+            country: "United States"
+          coordinates:
+            latitude: 34.0522
+            longitude: -118.2437
+        destination:
+          address:
+            street: "456 Customer Way"
+            city: "New York"
+            state: "New York"
+            postal_code: "10001"
+            country: "United States"
+          coordinates:
+            latitude: 40.7128
+            longitude: -74.0060
+        packages:
+          - package_id: "550e8400-e29b-41d4-a716-446655440010"
+            weight:
+              value: 5.2
+              unit: "kg"
+            dimensions:
+              length: 30.0
+              width: 20.0
+              height: 15.0
+              unit: "cm"
+            contents:
+              - item_id: "LAPTOP-001"
+                description: "Dell XPS 13 Laptop"
+                quantity: 1
+                unit_value:
+                  amount: 1200.00
+                  currency: "USD"
+            value:
+              amount: 1200.00
+              currency: "USD"
+            fragile: true
+            hazardous: false
+        carrier: "UPS"
+        service_type: "express"
+        status: "in_transit"
+        estimated_delivery: "2024-10-03T17:00:00Z"
+        cost:
+          amount: 25.99
+          currency: "USD"
+    vehicles:
+      - vehicle_id: "550e8400-e29b-41d4-a716-446655440020"
+        license_plate: "LOG-123"
+        vehicle_type: "truck"
+        capacity:
+          value: 3500.0
+          unit: "kg"
+        current_location:
+          address:
+            street: "Interstate 40"
+            city: "Amarillo"
+            state: "Texas"
+            postal_code: "79101"
+            country: "United States"
+          coordinates:
+            latitude: 35.2220
+            longitude: -101.8313
+        driver_id: "550e8400-e29b-41d4-a716-446655440030"
+        status: "in_transit"
+    warehouses:
+      - warehouse_id: "550e8400-e29b-41d4-a716-446655440040"
+        name: "West Coast Distribution Center"
+        address:
+          street: "123 Warehouse Drive"
+          city: "Los Angeles"
+          state: "California"
+          postal_code: "90210"
+          country: "United States"
+        type: "distribution"
+        capacity_cubic_meters: 10000.0
+        current_utilization: 7500.0
+        operating_hours:
+          monday: "06:00-22:00"
+          tuesday: "06:00-22:00"
+          wednesday: "06:00-22:00"
+          thursday: "06:00-22:00"
+          friday: "06:00-22:00"
+          saturday: "08:00-18:00"
+          sunday: "closed"
+        contact:
+          phone: "+13105551234"
+          email: "warehouse.la@logistics.com"
+        climate_controlled: true
 properties:
   shipments:
     type: array

--- a/tests/load/manufacturing/manufacturing.tests.yaml
+++ b/tests/load/manufacturing/manufacturing.tests.yaml
@@ -1,0 +1,72 @@
+version: 1.0.0
+tests:
+  manufacturing.yaml#/$defs/Product:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/ProductSpecifications:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/TemperatureRange:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/BOMItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/ProductionOrder:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/Machine:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/MachineLocation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/MachineCapacity:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/QualityCheck:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  manufacturing.yaml#/$defs/Measurement:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/manufacturing/manufacturing.yaml
+++ b/tests/load/manufacturing/manufacturing.yaml
@@ -1,6 +1,105 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Manufacturing Operations Schema"
 type: object
+examples:
+  - products:
+      - product_id: "550e8400-e29b-41d4-a716-446655440001"
+        part_number: "ENG-BLOCK-V8"
+        name: "V8 Engine Block"
+        description: "Cast iron engine block for 5.0L V8 engine with precision machined cylinder bores"
+        category: "component"
+        specifications:
+          material: "Cast Iron"
+          tolerance: "±0.05mm"
+          surface_finish: "Ra 1.6"
+          hardness: "HRC 45-50"
+          operating_temperature:
+            minimum: -40.0
+            maximum: 150.0
+        bill_of_materials:
+          - item_id: "550e8400-e29b-41d4-a716-446655440010"
+            part_number: "CI-INGOT-001"
+            description: "Cast Iron Ingot"
+            quantity: 25.0
+            unit: "kg"
+            cost_per_unit:
+              amount: 2.50
+              currency: "USD"
+        cost:
+          amount: 850.00
+          currency: "USD"
+        weight:
+          value: 85.5
+          unit: "kg"
+        dimensions:
+          length: 60.0
+          width: 45.0
+          height: 35.0
+          unit: "cm"
+    production_orders:
+      - order_id: "550e8400-e29b-41d4-a716-446655440020"
+        order_number: "PO-2024-001234"
+        product_id: "550e8400-e29b-41d4-a716-446655440001"
+        quantity: 100
+        priority: "high"
+        status: "in_progress"
+        planned_start_date: "2024-10-01"
+        planned_end_date: "2024-10-15"
+        actual_start_date: "2024-10-01"
+        assigned_line: "Line A"
+        machine_ids: ["550e8400-e29b-41d4-a716-446655440030"]
+        operator_id: "OP-001"
+        progress_percentage: 65.0
+        units_completed: 65
+        estimated_completion: "2024-10-14T16:30:00Z"
+    machines:
+      - machine_id: "550e8400-e29b-41d4-a716-446655440030"
+        machine_code: "CNC-001"
+        name: "Haas VF-4 CNC Machining Center"
+        type: "cnc_machine"
+        manufacturer: "Haas Automation"
+        model: "VF-4"
+        year_installed: 2020
+        status: "operational"
+        location:
+          building: "Manufacturing Plant A"
+          floor: "1"
+          cell: "C-03"
+        specifications:
+          max_spindle_speed: 8100
+          spindle_taper: "40-Taper"
+          table_size: "1270x510mm"
+          axis_travel: "1270x510x635mm"
+          tool_capacity: 20
+        maintenance_schedule:
+          last_service: "2024-09-01"
+          next_service: "2024-12-01"
+          service_interval_days: 90
+        operating_hours: 2450.5
+        efficiency_rating: 0.92
+    quality_checks:
+      - check_id: "550e8400-e29b-41d4-a716-446655440040"
+        product_id: "550e8400-e29b-41d4-a716-446655440001"
+        production_order_id: "550e8400-e29b-41d4-a716-446655440020"
+        check_type: "dimensional"
+        inspector_id: "QC-001"
+        check_date: "2024-10-05T14:30:00Z"
+        status: "passed"
+        measurements:
+          - parameter: "Cylinder Bore Diameter"
+            specification: "86.00mm ±0.05mm"
+            measured_value: 86.02
+            unit: "mm"
+            within_tolerance: true
+          - parameter: "Surface Roughness"
+            specification: "Ra 1.6 max"
+            measured_value: 1.4
+            unit: "Ra"
+            within_tolerance: true
+        defects_found: []
+        corrective_actions: []
+        passed: true
+        notes: "All measurements within specification. Quality approved for next production stage."
 properties:
   products:
     type: array

--- a/tests/load/music_streaming/music_streaming.tests.yaml
+++ b/tests/load/music_streaming/music_streaming.tests.yaml
@@ -1,0 +1,65 @@
+version: 1.0.0
+tests:
+  music_streaming.yaml#/$defs/User:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/ListeningPreferences:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/Artist:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/BandMember:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/Album:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/Track:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/AudioFeatures:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/Playlist:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  music_streaming.yaml#/$defs/PlaylistTrack:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/music_streaming/music_streaming.yaml
+++ b/tests/load/music_streaming/music_streaming.yaml
@@ -1,6 +1,90 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "Music Streaming Platform Schema"
 type: object
+examples:
+  - users:
+      - user_id: "550e8400-e29b-41d4-a716-446655440001"
+        username: "music_lover2024"
+        email: "sarah.music@email.com"
+        name:
+          first_name: "Sarah"
+          last_name: "Johnson"
+        date_of_birth: "1995-06-15"
+        country: "US"
+        subscription_type: "premium"
+        subscription_start: "2024-01-15T00:00:00Z"
+        subscription_end: "2025-01-15T00:00:00Z"
+        listening_history:
+          - track_id: "550e8400-e29b-41d4-a716-446655440020"
+            played_at: "2024-10-01T14:30:00Z"
+            duration_played: 180
+            completed: true
+        preferences:
+          favorite_genres: ["pop", "rock", "indie"]
+          explicit_content: false
+          audio_quality: "high"
+          autoplay: true
+        created_at: "2024-01-15T10:00:00Z"
+        last_active: "2024-10-01T15:45:00Z"
+    artists:
+      - artist_id: "550e8400-e29b-41d4-a716-446655440010"
+        name: "Taylor Swift"
+        bio: "American singer-songwriter known for her narrative songwriting and genre versatility"
+        country: "US"
+        genres: ["pop", "country", "indie"]
+        debut_year: 2006
+        verified: true
+        monthly_listeners: 85000000
+        image_url: "https://music.example.com/artists/taylor-swift.jpg"
+        social_media:
+          instagram: "@taylorswift"
+          twitter: "@taylorswift13"
+          website: "https://taylorswift.com"
+    albums:
+      - album_id: "550e8400-e29b-41d4-a716-446655440015"
+        title: "1989 (Taylor's Version)"
+        artist_id: "550e8400-e29b-41d4-a716-446655440010"
+        release_date: "2023-10-27"
+        album_type: "studio"
+        genre: "pop"
+        total_tracks: 21
+        duration_seconds: 4680
+        cover_art_url: "https://music.example.com/covers/1989-tv.jpg"
+        label: "Taylor Swift Productions"
+        producer: "Taylor Swift, Jack Antonoff"
+        explicit: false
+    tracks:
+      - track_id: "550e8400-e29b-41d4-a716-446655440020"
+        title: "Shake It Off (Taylor's Version)"
+        artist_id: "550e8400-e29b-41d4-a716-446655440010"
+        album_id: "550e8400-e29b-41d4-a716-446655440015"
+        track_number: 6
+        duration_seconds: 219
+        genre: "pop"
+        explicit: false
+        isrc: "USCJY2359876"
+        audio_url: "https://music.example.com/audio/shake-it-off-tv.mp3"
+        preview_url: "https://music.example.com/preview/shake-it-off-tv.mp3"
+        lyrics: "I stay out too late, got nothing in my brain..."
+        play_count: 1250000000
+        popularity: 95
+        release_date: "2023-10-27"
+        available_markets: ["US", "CA", "GB", "AU"]
+    playlists:
+      - playlist_id: "550e8400-e29b-41d4-a716-446655440030"
+        name: "My Favorites 2024"
+        description: "A collection of my favorite songs discovered this year"
+        user_id: "550e8400-e29b-41d4-a716-446655440001"
+        public: true
+        collaborative: false
+        track_ids: ["550e8400-e29b-41d4-a716-446655440020"]
+        total_tracks: 1
+        total_duration_seconds: 219
+        cover_image_url: "https://music.example.com/playlists/my-favorites-2024.jpg"
+        created_at: "2024-01-20T12:00:00Z"
+        updated_at: "2024-10-01T14:30:00Z"
+        follower_count: 25
+        tags: ["favorites", "2024", "pop"]
 properties:
   users:
     type: array

--- a/tests/load/news_publishing/news_publishing.tests.yaml
+++ b/tests/load/news_publishing/news_publishing.tests.yaml
@@ -1,0 +1,30 @@
+version: 1.0.0
+tests:
+  news_publishing.yaml#/$defs/Article:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  news_publishing.yaml#/$defs/Author:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  news_publishing.yaml#/$defs/Category:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  news_publishing.yaml#/$defs/SEO:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/news_publishing/news_publishing.yaml
+++ b/tests/load/news_publishing/news_publishing.yaml
@@ -1,6 +1,69 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 title: "News Publishing Platform Schema"
 type: object
+examples:
+  - articles:
+      - article_id: "550e8400-e29b-41d4-a716-446655440001"
+        title: "Breaking: Major Breakthrough in Renewable Energy Technology"
+        subtitle: "New solar panel design achieves record 47% efficiency in laboratory tests"
+        slug: "renewable-energy-breakthrough-solar-panel-efficiency"
+        content: "Scientists at the Massachusetts Institute of Technology have achieved a groundbreaking milestone in renewable energy technology with the development of a new solar panel design that reaches 47% efficiency in converting sunlight to electricity. This represents a significant improvement over current commercial solar panels, which typically achieve 20-22% efficiency. The breakthrough could revolutionize the solar energy industry and accelerate the global transition to clean energy."
+        excerpt: "MIT scientists develop solar panel technology with record-breaking 47% efficiency, potentially revolutionizing renewable energy industry."
+        author_id: "550e8400-e29b-41d4-a716-446655440010"
+        category_id: "550e8400-e29b-41d4-a716-446655440020"
+        tags: ["renewable energy", "solar power", "technology", "climate change", "MIT"]
+        status: "published"
+        featured_image:
+          url: "https://news.example.com/images/solar-panels-breakthrough.jpg"
+          alt: "Advanced solar panels in laboratory setting"
+          caption: "MIT researchers testing the new high-efficiency solar panel design"
+        publication_date: "2024-10-01T09:00:00Z"
+        last_modified: "2024-10-01T09:15:00Z"
+        view_count: 125000
+        share_count: 2500
+        reading_time_minutes: 4
+        language: "en"
+        priority: "high"
+        seo:
+          meta_description: "MIT scientists achieve record 47% efficiency in new solar panel design, marking major breakthrough in renewable energy technology."
+          keywords: ["solar energy", "renewable technology", "MIT research", "energy efficiency"]
+    authors:
+      - author_id: "550e8400-e29b-41d4-a716-446655440010"
+        name:
+          first_name: "Jessica"
+          last_name: "Chen"
+        email: "jessica.chen@newsorg.com"
+        bio: "Science and technology reporter with 8 years of experience covering breakthrough research and innovation. Specialized in renewable energy and climate technology."
+        profile_image: "https://news.example.com/authors/jessica-chen.jpg"
+        specialties: ["science", "technology", "renewable energy", "climate"]
+        social_media:
+          twitter: "@jessicachen_sci"
+          linkedin: "jessica-chen-science"
+        hire_date: "2018-03-15"
+        articles_published: 347
+        average_views_per_article: 15000
+    categories:
+      - category_id: "550e8400-e29b-41d4-a716-446655440020"
+        name: "Science & Technology"
+        description: "Latest developments in scientific research, technological innovations, and their impact on society"
+        slug: "science-technology"
+        parent_category_id: null
+        color: "#2E86C1"
+        icon: "microscope"
+        display_order: 3
+        article_count: 1247
+        active: true
+    comments:
+      - comment_id: "550e8400-e29b-41d4-a716-446655440030"
+        content: "This is incredible news! Can't wait to see this technology make it to market. Great job MIT!"
+        author_id: "550e8400-e29b-41d4-a716-446655440040"
+        post_id: "550e8400-e29b-41d4-a716-446655440001"
+        parent_comment_id: null
+        created_at: "2024-10-01T10:30:00Z"
+        likes: 45
+        replies: 3
+        status: "approved"
+        reported: false
 properties:
   articles:
     type: array

--- a/tests/load/real_estate/real_estate.tests.yaml
+++ b/tests/load/real_estate/real_estate.tests.yaml
@@ -1,0 +1,58 @@
+version: 1.0.0
+tests:
+  real_estate.yaml#/$defs/Property:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/Agent:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/Listing:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/OpenHouse:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/Transaction:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/PartyInfo:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/Financing:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  real_estate.yaml#/$defs/Commission:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/real_estate/real_estate.yaml
+++ b/tests/load/real_estate/real_estate.yaml
@@ -21,6 +21,30 @@ properties:
 $defs:
   Property:
     type: object
+    examples:
+      - property_id: "550e8400-e29b-41d4-a716-446655440001"
+        address:
+          street: "1234 Oak Street"
+          city: "Beverly Hills"
+          state: "California"
+          postal_code: "90210"
+          country: "United States"
+        property_type: "house"
+        bedrooms: 4
+        bathrooms: 3.5
+        square_feet: 2850
+        lot_size_sqft: 8000
+        year_built: 2018
+        features: ["pool", "garage", "fireplace", "hardwood_floors", "granite_countertops"]
+        hoa_fee:
+          amount: 250.00
+          currency: "USD"
+        property_taxes:
+          amount: 12500.00
+          currency: "USD"
+        zoning: "residential"
+        condition: "excellent"
+        photos: ["https://example.com/photos/001.jpg", "https://example.com/photos/002.jpg"]
     properties:
       property_id:
         type: string
@@ -73,6 +97,20 @@ $defs:
     required: ["property_id", "address", "property_type", "square_feet"]
   Agent:
     type: object
+    examples:
+      - agent_id: "550e8400-e29b-41d4-a716-446655440010"
+        name:
+          first_name: "Sarah"
+          last_name: "Williams"
+        email: "sarah.williams@premierrealty.com"
+        phone: "+15551234567"
+        license_number: "RE#01234567"
+        brokerage: "Premier Realty Group"
+        specialties: ["luxury", "residential"]
+        years_experience: 8
+        commission_rate: 0.03
+        rating: 4.8
+        total_sales: 127
     properties:
       agent_id:
         type: string
@@ -112,6 +150,29 @@ $defs:
     required: ["agent_id", "name", "email", "phone", "license_number", "brokerage"]
   Listing:
     type: object
+    examples:
+      - listing_id: "550e8400-e29b-41d4-a716-446655440020"
+        property_id: "550e8400-e29b-41d4-a716-446655440001"
+        agent_id: "550e8400-e29b-41d4-a716-446655440010"
+        listing_type: "sale"
+        price:
+          amount: 1250000.00
+          currency: "USD"
+        price_per_sqft:
+          amount: 438.60
+          currency: "USD"
+        status: "active"
+        list_date: "2024-03-15"
+        days_on_market: 45
+        description: "Stunning 4-bedroom luxury home in prestigious Beverly Hills neighborhood. Features include gourmet kitchen, pool, and beautiful landscaping."
+        virtual_tour_url: "https://example.com/virtual-tour/001"
+        showing_instructions: "Please call listing agent 24 hours in advance"
+        open_houses:
+          - open_house_id: "550e8400-e29b-41d4-a716-446655440030"
+            date: "2024-04-20"
+            start_time: "14:00"
+            end_time: "16:00"
+            notes: "Refreshments will be provided"
     properties:
       listing_id:
         type: string

--- a/tests/load/recipe_management/recipe_management.tests.yaml
+++ b/tests/load/recipe_management/recipe_management.tests.yaml
@@ -1,0 +1,65 @@
+version: 1.0.0
+tests:
+  recipe_management.yaml#/$defs/Recipe:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/Ingredient:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/RecipeIngredient:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/Instruction:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/NutritionInfo:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/User:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/MealPlan:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/PlannedMeal:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  recipe_management.yaml#/$defs/ShoppingItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/recipe_management/recipe_management.yaml
+++ b/tests/load/recipe_management/recipe_management.yaml
@@ -21,6 +21,44 @@ properties:
 $defs:
   Recipe:
     type: object
+    examples:
+      - recipe_id: "550e8400-e29b-41d4-a716-446655440001"
+        title: "Classic Spaghetti Carbonara"
+        description: "Traditional Italian pasta dish with eggs, cheese, and pancetta"
+        author_id: "550e8400-e29b-41d4-a716-446655440010"
+        cuisine_type: "italian"
+        difficulty: "medium"
+        prep_time_minutes: 15
+        cook_time_minutes: 20
+        total_time_minutes: 35
+        servings: 4
+        ingredients:
+          - ingredient_id: "550e8400-e29b-41d4-a716-446655440020"
+            quantity: 400
+            unit: "gram"
+            preparation: "cooked al dente"
+          - ingredient_id: "550e8400-e29b-41d4-a716-446655440021"
+            quantity: 4
+            unit: "piece"
+            preparation: "large, room temperature"
+        instructions:
+          - step_number: 1
+            description: "Bring a large pot of salted water to boil and cook spaghetti until al dente"
+            duration_minutes: 12
+          - step_number: 2
+            description: "In a large bowl, whisk together eggs and grated cheese"
+            duration_minutes: 3
+        nutrition:
+          calories: 520
+          protein_g: 22.5
+          carbs_g: 65.0
+          fat_g: 18.5
+          fiber_g: 3.2
+          sodium_mg: 680
+        tags: ["quick", "italian"]
+        rating: 4.7
+        review_count: 156
+        created_date: "2024-01-15T10:30:00Z"
     properties:
       recipe_id:
         type: string
@@ -87,6 +125,19 @@ $defs:
     required: ["recipe_id", "title", "author_id", "prep_time_minutes", "cook_time_minutes", "servings", "ingredients", "instructions"]
   Ingredient:
     type: object
+    examples:
+      - ingredient_id: "550e8400-e29b-41d4-a716-446655440020"
+        name: "Spaghetti"
+        category: "grains"
+        default_unit: "gram"
+        nutrition_per_100g:
+          calories: 371
+          protein_g: 13.0
+          carbs_g: 74.0
+          fat_g: 1.5
+          fiber_g: 3.2
+          sodium_mg: 6
+        allergens: ["gluten"]
     properties:
       ingredient_id:
         type: string
@@ -179,6 +230,18 @@ $defs:
         minimum: 0
   User:
     type: object
+    examples:
+      - user_id: "550e8400-e29b-41d4-a716-446655440010"
+        username: "chef_maria"
+        email: "maria.rossi@email.com"
+        name:
+          first_name: "Maria"
+          last_name: "Rossi"
+        dietary_restrictions: ["vegetarian"]
+        favorite_cuisines: ["italian", "mediterranean"]
+        cooking_skill: "advanced"
+        favorite_recipes: ["550e8400-e29b-41d4-a716-446655440001"]
+        created_recipes: ["550e8400-e29b-41d4-a716-446655440001"]
     properties:
       user_id:
         type: string

--- a/tests/load/restaurant_pos/restaurant_pos.tests.yaml
+++ b/tests/load/restaurant_pos/restaurant_pos.tests.yaml
@@ -1,0 +1,44 @@
+version: 1.0.0
+tests:
+  restaurant_pos.yaml#/$defs/MenuItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  restaurant_pos.yaml#/$defs/Order:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  restaurant_pos.yaml#/$defs/OrderItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  restaurant_pos.yaml#/$defs/Table:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  restaurant_pos.yaml#/$defs/Staff:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  restaurant_pos.yaml#/$defs/Shift:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/restaurant_pos/restaurant_pos.yaml
+++ b/tests/load/restaurant_pos/restaurant_pos.yaml
@@ -21,6 +21,22 @@ properties:
 $defs:
   MenuItem:
     type: object
+    examples:
+      - item_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Grilled Salmon"
+        description: "Fresh Atlantic salmon grilled to perfection, served with seasonal vegetables and rice pilaf"
+        category: "entree"
+        price:
+          amount: 28.95
+          currency: "USD"
+        cost:
+          amount: 12.50
+          currency: "USD"
+        ingredients: ["salmon", "rice", "broccoli", "carrots", "olive oil", "lemon"]
+        allergens: ["fish"]
+        available: true
+        preparation_time: 18
+        calories: 450
     properties:
       item_id:
         type: string
@@ -59,6 +75,38 @@ $defs:
     required: ["item_id", "name", "category", "price", "available"]
   Order:
     type: object
+    examples:
+      - order_id: "550e8400-e29b-41d4-a716-446655440010"
+        order_number: 142
+        table_id: "550e8400-e29b-41d4-a716-446655440020"
+        server_id: "550e8400-e29b-41d4-a716-446655440030"
+        items:
+          - item_id: "550e8400-e29b-41d4-a716-446655440001"
+            quantity: 2
+            unit_price:
+              amount: 28.95
+              currency: "USD"
+            total_price:
+              amount: 57.90
+              currency: "USD"
+            modifications: ["no vegetables", "extra lemon"]
+            status: "preparing"
+        subtotal:
+          amount: 57.90
+          currency: "USD"
+        tax_amount:
+          amount: 5.21
+          currency: "USD"
+        tip_amount:
+          amount: 12.00
+          currency: "USD"
+        total_amount:
+          amount: 75.11
+          currency: "USD"
+        payment_method: "credit_card"
+        status: "preparing"
+        order_time: "2024-03-15T18:30:00Z"
+        special_instructions: "Table celebrating anniversary"
     properties:
       order_id:
         type: string
@@ -147,6 +195,22 @@ $defs:
     required: ["table_id", "table_number", "capacity", "location", "status"]
   Staff:
     type: object
+    examples:
+      - staff_id: "550e8400-e29b-41d4-a716-446655440030"
+        employee_id: "EMP-2024-001"
+        name:
+          first_name: "Emily"
+          last_name: "Johnson"
+        role: "server"
+        hourly_rate:
+          amount: 15.50
+          currency: "USD"
+        hire_date: "2024-01-15"
+        status: "active"
+        shift:
+          start_time: "17:00"
+          end_time: "23:00"
+          days: ["friday", "saturday", "sunday"]
     properties:
       staff_id:
         type: string

--- a/tests/load/ride_sharing/ride_sharing.tests.yaml
+++ b/tests/load/ride_sharing/ride_sharing.tests.yaml
@@ -1,0 +1,37 @@
+version: 1.0.0
+tests:
+  ride_sharing.yaml#/$defs/Rider:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ride_sharing.yaml#/$defs/RiderPreferences:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ride_sharing.yaml#/$defs/Driver:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ride_sharing.yaml#/$defs/DriverEarnings:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  ride_sharing.yaml#/$defs/Ride:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/ride_sharing/ride_sharing.yaml
+++ b/tests/load/ride_sharing/ride_sharing.yaml
@@ -18,6 +18,47 @@ properties:
     type: array
     items:
       $ref: "../fleet_management/fleet_management.yaml#/$defs/Vehicle"
+examples:
+  - riders:
+      - rider_id: "550e8400-e29b-41d4-a716-446655440000"
+        name:
+          first: "John"
+          last: "Doe"
+        email: "john@example.com"
+        phone: "+1234567890"
+    drivers:
+      - driver_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        name:
+          first: "Jane"
+          last: "Smith"
+        email: "jane@example.com"
+        phone: "+1987654321"
+        license:
+          license_number: "D123456789"
+          state: "CA"
+          expiry_date: "2025-12-31"
+        status: "online"
+    rides:
+      - ride_id: "123e4567-e89b-12d3-a456-426614174000"
+        rider_id: "550e8400-e29b-41d4-a716-446655440000"
+        pickup_location:
+          latitude: 37.7749
+          longitude: -122.4194
+          address: "123 Main St, San Francisco, CA"
+        dropoff_location:
+          latitude: 37.7849
+          longitude: -122.4094
+          address: "456 Oak St, San Francisco, CA"
+        requested_time: "2024-01-15T14:30:00Z"
+        status: "requested"
+        ride_type: "economy"
+    vehicles:
+      - vehicle_id: "987fcdeb-51a2-43d8-b123-456789abcdef"
+        make: "Toyota"
+        model: "Prius"
+        year: 2022
+        license_plate: "ABC123"
+        status: "active"
 $defs:
   Rider:
     type: object

--- a/tests/load/smart_home/smart_home.tests.yaml
+++ b/tests/load/smart_home/smart_home.tests.yaml
@@ -1,0 +1,65 @@
+version: 1.0.0
+tests:
+  smart_home.yaml#/$defs/Device:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/LightProperties:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/ThermostatProperties:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/LockProperties:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/Room:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/Automation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/Trigger:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/Condition:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  smart_home.yaml#/$defs/Action:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/smart_home/smart_home.yaml
+++ b/tests/load/smart_home/smart_home.yaml
@@ -21,6 +21,21 @@ properties:
 $defs:
   Device:
     type: object
+    examples:
+      - device_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Living Room Main Light"
+        device_type: "light"
+        manufacturer: "Philips"
+        model: "Hue Color A21"
+        room_id: "550e8400-e29b-41d4-a716-446655440010"
+        status: "online"
+        battery_level: 85
+        last_seen: "2024-03-15T18:30:00Z"
+        properties:
+          brightness: 75
+          color_temperature: 3000
+          rgb_color: "#FFAA00"
+          on: true
     properties:
       device_id:
         type: string
@@ -107,6 +122,12 @@ $defs:
     required: ["locked"]
   Room:
     type: object
+    examples:
+      - room_id: "550e8400-e29b-41d4-a716-446655440010"
+        name: "Living Room"
+        room_type: "living_room"
+        floor: 1
+        area_sqft: 320.5
     properties:
       room_id:
         type: string
@@ -126,6 +147,25 @@ $defs:
     required: ["room_id", "name", "room_type", "floor"]
   Automation:
     type: object
+    examples:
+      - automation_id: "550e8400-e29b-41d4-a716-446655440020"
+        name: "Evening Routine"
+        description: "Automatically dim lights and lock doors at 10 PM"
+        enabled: true
+        triggers:
+          - trigger_type: "time"
+            time: "22:00"
+        conditions: []
+        actions:
+          - device_id: "550e8400-e29b-41d4-a716-446655440001"
+            action_type: "set_property"
+            property: "brightness"
+            value: 30
+          - device_id: "550e8400-e29b-41d4-a716-446655440030"
+            action_type: "set_property"
+            property: "locked"
+            value: true
+        last_triggered: "2024-03-14T22:00:00Z"
     properties:
       automation_id:
         type: string

--- a/tests/load/social_media/social_media.tests.yaml
+++ b/tests/load/social_media/social_media.tests.yaml
@@ -1,0 +1,48 @@
+version: 1.0.0
+tests:
+  social_media.yaml#/$defs/User:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  social_media.yaml#/$defs/UserProfile:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  social_media.yaml#/$defs/Post:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  social_media.yaml#/$defs/Comment:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  social_media.yaml#/$schema:
+    valid:
+    invalid:
+  social_media.yaml#/title:
+    valid:
+    invalid:
+  social_media.yaml#/type:
+    valid:
+    invalid:
+  social_media.yaml#/properties:
+    valid:
+    invalid:
+  social_media.yaml#/examples:
+    valid:
+    invalid:
+  social_media.yaml#/$defs:
+    valid:
+    invalid:

--- a/tests/load/social_media/social_media.yaml
+++ b/tests/load/social_media/social_media.yaml
@@ -14,6 +14,22 @@ properties:
     type: array
     items:
       $ref: "#/$defs/Comment"
+examples:
+  - users:
+      - user_id: "550e8400-e29b-41d4-a716-446655440000"
+        username: "john_doe"
+        email: "john@example.com"
+    posts:
+      - post_id: "123e4567-e89b-12d3-a456-426614174000"
+        user_id: "550e8400-e29b-41d4-a716-446655440000"
+        content: "Hello world!"
+        created_at: "2024-01-15T10:30:00Z"
+    comments:
+      - comment_id: "987fcdeb-51a2-43d8-b123-456789abcdef"
+        post_id: "123e4567-e89b-12d3-a456-426614174000"
+        user_id: "550e8400-e29b-41d4-a716-446655440000"
+        content: "Great post!"
+        created_at: "2024-01-15T10:45:00Z"
 $defs:
   User:
     type: object
@@ -39,6 +55,19 @@ $defs:
         type: boolean
         default: false
     required: ["user_id", "username", "email"]
+    examples:
+      - user_id: "550e8400-e29b-41d4-a716-446655440000"
+        username: "john_doe"
+        email: "john@example.com"
+        profile:
+          display_name: "John Doe"
+          bio: "Tech enthusiast and coffee lover"
+          avatar_url: "https://example.com/avatar.jpg"
+          location: "San Francisco"
+          birth_date: "1990-05-15"
+        followers_count: 1250
+        following_count: 320
+        verified: false
   UserProfile:
     type: object
     properties:
@@ -60,6 +89,13 @@ $defs:
       birth_date:
         type: string
         format: date
+    examples:
+      - display_name: "John Doe"
+        bio: "Tech enthusiast and coffee lover ☕"
+        avatar_url: "https://example.com/avatar.jpg"
+        location: "San Francisco, CA"
+        website: "https://johndoe.dev"
+        birth_date: "1990-05-15"
   Post:
     type: object
     properties:
@@ -98,6 +134,16 @@ $defs:
         type: string
         format: date-time
     required: ["post_id", "user_id", "content", "created_at"]
+    examples:
+      - post_id: "123e4567-e89b-12d3-a456-426614174000"
+        user_id: "550e8400-e29b-41d4-a716-446655440000"
+        content: "Just discovered an amazing new coffee shop! ☕ #coffee #discovery"
+        media_urls: ["https://example.com/coffee-shop.jpg"]
+        hashtags: ["#coffee", "#discovery"]
+        mentions: ["@coffeelover"]
+        likes_count: 42
+        shares_count: 8
+        created_at: "2024-01-15T10:30:00Z"
   Comment:
     type: object
     properties:
@@ -123,3 +169,10 @@ $defs:
         type: string
         format: date-time
     required: ["comment_id", "post_id", "user_id", "content", "created_at"]
+    examples:
+      - comment_id: "987fcdeb-51a2-43d8-b123-456789abcdef"
+        post_id: "123e4567-e89b-12d3-a456-426614174000"
+        user_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        content: "Which coffee shop? I'm always looking for new places!"
+        likes_count: 3
+        created_at: "2024-01-15T10:45:00Z"

--- a/tests/load/space_exploration/space_exploration.tests.yaml
+++ b/tests/load/space_exploration/space_exploration.tests.yaml
@@ -1,0 +1,65 @@
+version: 1.0.0
+tests:
+  space_exploration.yaml#/$defs/Mission:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/Spacecraft:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/PropulsionSystem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/LifeSupport:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/CommunicationSystem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/ScientificInstrument:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/Astronaut:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/CelestialBody:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  space_exploration.yaml#/$defs/TelemetryData:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/space_exploration/space_exploration.yaml
+++ b/tests/load/space_exploration/space_exploration.yaml
@@ -25,6 +25,23 @@ properties:
 $defs:
   Mission:
     type: object
+    examples:
+      - mission_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Artemis III"
+        mission_type: "exploration"
+        agency: "NASA"
+        launch_date: "2025-09-15T10:30:00Z"
+        planned_duration_days: 45
+        status: "planned"
+        destination: "550e8400-e29b-41d4-a716-446655440020"
+        objectives: ["Land on lunar south pole", "Establish lunar base camp", "Conduct geological surveys"]
+        budget:
+          amount: 4200000000.00
+          currency: "USD"
+        crew: ["550e8400-e29b-41d4-a716-446655440010", "550e8400-e29b-41d4-a716-446655440011"]
+        spacecraft_id: "550e8400-e29b-41d4-a716-446655440030"
+        launch_site: "Kennedy Space Center LC-39A"
+        mission_control: "Johnson Space Center"
     properties:
       mission_id:
         type: string
@@ -75,6 +92,28 @@ $defs:
     required: ["mission_id", "name", "mission_type", "agency", "launch_date", "status", "objectives", "spacecraft_id"]
   Spacecraft:
     type: object
+    examples:
+      - spacecraft_id: "550e8400-e29b-41d4-a716-446655440030"
+        name: "Orion Artemis III"
+        spacecraft_type: "capsule"
+        manufacturer: "Lockheed Martin"
+        launch_mass_kg: 25400.0
+        dimensions:
+          length_cm: 500.0
+          width_cm: 500.0
+          height_cm: 340.0
+          weight_kg: 25400.0
+        power_source: "solar"
+        power_output_watts: 11200.0
+        propulsion_system:
+          type: "chemical"
+          fuel_type: "MMH/NTO"
+          thrust_newtons: 33400.0
+          specific_impulse_seconds: 316.0
+          fuel_capacity_kg: 8800.0
+        crew_capacity: 4
+        operational_status: "active"
+        launch_date: "2025-09-15T10:30:00Z"
     properties:
       spacecraft_id:
         type: string
@@ -211,6 +250,26 @@ $defs:
     required: ["instrument_id", "name", "type", "purpose", "mass_kg", "power_consumption_watts"]
   Astronaut:
     type: object
+    examples:
+      - astronaut_id: "550e8400-e29b-41d4-a716-446655440010"
+        name:
+          first_name: "Christina"
+          middle_name: "Hammock"
+          last_name: "Koch"
+        call_sign: "Station"
+        nationality: "US"
+        date_of_birth: "1979-02-29"
+        agency: "NASA"
+        astronaut_class: "Group 21"
+        selection_date: "2013-06-17"
+        total_space_time_hours: 5248.5
+        total_eva_time_hours: 42.5
+        missions_flown: ["550e8400-e29b-41d4-a716-446655440040"]
+        specializations: ["mission_specialist", "flight_engineer"]
+        medical_clearance:
+          status: "active"
+          last_exam_date: "2024-12-15"
+          next_exam_date: "2025-06-15"
     properties:
       astronaut_id:
         type: string

--- a/tests/load/supply_chain/supply_chain.tests.yaml
+++ b/tests/load/supply_chain/supply_chain.tests.yaml
@@ -1,0 +1,23 @@
+version: 1.0.0
+tests:
+  supply_chain.yaml#/$defs/Supplier:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  supply_chain.yaml#/$defs/PurchaseOrder:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  supply_chain.yaml#/$defs/POItem:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/supply_chain/supply_chain.yaml
+++ b/tests/load/supply_chain/supply_chain.yaml
@@ -21,6 +21,27 @@ properties:
 $defs:
   Supplier:
     type: object
+    examples:
+      - supplier_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Global Electronics Supply Co."
+        contact_person:
+          first_name: "David"
+          last_name: "Martinez"
+        email: "david.martinez@globalsupply.com"
+        phone: "+14155551234"
+        address:
+          street: "1500 Industrial Blvd"
+          city: "San Jose"
+          state: "California"
+          postal_code: "95112"
+          country: "United States"
+        tax_id: "12-3456789"
+        payment_terms: "net_30"
+        credit_limit:
+          amount: 500000.00
+          currency: "USD"
+        rating: 4
+        products_supplied: ["550e8400-e29b-41d4-a716-446655440010"]
     properties:
       supplier_id:
         type: string
@@ -57,6 +78,38 @@ $defs:
     required: ["supplier_id", "name", "contact_person", "email", "phone", "address", "payment_terms"]
   PurchaseOrder:
     type: object
+    examples:
+      - po_id: "550e8400-e29b-41d4-a716-446655440020"
+        po_number: "PO-20240315"
+        supplier_id: "550e8400-e29b-41d4-a716-446655440001"
+        order_date: "2024-03-15"
+        expected_delivery: "2024-03-30"
+        status: "sent"
+        items:
+          - product_id: "550e8400-e29b-41d4-a716-446655440010"
+            sku: "CHIP-ARM-M1-256"
+            description: "ARM M1 Microprocessor 256GB"
+            quantity: 100
+            unit_price:
+              amount: 145.50
+              currency: "USD"
+            total_price:
+              amount: 14550.00
+              currency: "USD"
+            expected_delivery: "2024-03-30"
+        subtotal:
+          amount: 14550.00
+          currency: "USD"
+        tax_amount:
+          amount: 1164.00
+          currency: "USD"
+        shipping_cost:
+          amount: 125.00
+          currency: "USD"
+        total_amount:
+          amount: 15839.00
+          currency: "USD"
+        payment_terms: "net_30"
     properties:
       po_id:
         type: string

--- a/tests/load/video_streaming/video_streaming.tests.yaml
+++ b/tests/load/video_streaming/video_streaming.tests.yaml
@@ -1,0 +1,44 @@
+version: 1.0.0
+tests:
+  video_streaming.yaml#/$defs/Video:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  video_streaming.yaml#/$defs/Channel:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  video_streaming.yaml#/$defs/Playlist:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  video_streaming.yaml#/$defs/PlaylistVideo:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  video_streaming.yaml#/$defs/Subtitle:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  video_streaming.yaml#/$defs/Monetization:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/video_streaming/video_streaming.yaml
+++ b/tests/load/video_streaming/video_streaming.yaml
@@ -18,6 +18,36 @@ properties:
     type: array
     items:
       $ref: "#/$defs/Playlist"
+examples:
+  - videos:
+      - video_id: "550e8400-e29b-41d4-a716-446655440000"
+        title: "My First Video"
+        channel_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        duration_seconds: 300
+        file_url: "https://example.com/video.mp4"
+        upload_date: "2024-01-15T10:00:00Z"
+        visibility: "public"
+        category: "entertainment"
+    users:
+      - user_id: "123e4567-e89b-12d3-a456-426614174000"
+        username: "creator1"
+        email: "creator@example.com"
+    channels:
+      - channel_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        name: "My Channel"
+        owner_id: "123e4567-e89b-12d3-a456-426614174000"
+        creation_date: "2024-01-01T00:00:00Z"
+        category: "entertainment"
+    playlists:
+      - playlist_id: "987fcdeb-51a2-43d8-b123-456789abcdef"
+        title: "My Playlist"
+        channel_id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        visibility: "public"
+        creation_date: "2024-01-10T00:00:00Z"
+        videos:
+          - video_id: "550e8400-e29b-41d4-a716-446655440000"
+            position: 1
+            added_date: "2024-01-10T00:00:00Z"
 $defs:
   Video:
     type: object

--- a/tests/load/weather_data/weather_data.tests.yaml
+++ b/tests/load/weather_data/weather_data.tests.yaml
@@ -1,0 +1,30 @@
+version: 1.0.0
+tests:
+  weather_data.yaml#/$defs/WeatherStation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  weather_data.yaml#/$defs/WeatherObservation:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  weather_data.yaml#/$defs/WeatherForecast:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases
+  weather_data.yaml#/$defs/ForecastPeriod:
+    valid:
+      TODO:
+        description: define test cases
+    invalid:
+      TODO:
+        description: define test cases

--- a/tests/load/weather_data/weather_data.yaml
+++ b/tests/load/weather_data/weather_data.yaml
@@ -17,6 +17,17 @@ properties:
 $defs:
   WeatherStation:
     type: object
+    examples:
+      - station_id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "San Francisco International Airport"
+        location:
+          latitude: 37.6213
+          longitude: -122.3790
+        elevation_meters: 3.7
+        station_type: "automatic"
+        operator: "National Weather Service"
+        installation_date: "2010-05-15"
+        sensors: []
     properties:
       station_id:
         type: string
@@ -43,6 +54,19 @@ $defs:
     required: ["station_id", "name", "location", "elevation_meters", "station_type"]
   WeatherObservation:
     type: object
+    examples:
+      - observation_id: "550e8400-e29b-41d4-a716-446655440010"
+        station_id: "550e8400-e29b-41d4-a716-446655440001"
+        timestamp: "2024-03-15T14:30:00Z"
+        temperature_celsius: 18.5
+        humidity_percent: 72.0
+        pressure_hpa: 1013.25
+        wind_speed_kmh: 12.8
+        wind_direction_degrees: 225
+        precipitation_mm: 0.0
+        visibility_km: 16.0
+        cloud_cover_percent: 25.0
+        weather_conditions: ["partly_cloudy"]
     properties:
       observation_id:
         type: string
@@ -92,6 +116,22 @@ $defs:
     required: ["observation_id", "station_id", "timestamp", "temperature_celsius", "humidity_percent", "pressure_hpa"]
   WeatherForecast:
     type: object
+    examples:
+      - forecast_id: "550e8400-e29b-41d4-a716-446655440020"
+        location:
+          latitude: 37.6213
+          longitude: -122.3790
+        forecast_date: "2024-03-16"
+        issued_time: "2024-03-15T18:00:00Z"
+        forecast_periods:
+          - period_start: "2024-03-16T06:00:00Z"
+            period_end: "2024-03-16T18:00:00Z"
+            temperature_high_celsius: 22.0
+            temperature_low_celsius: 15.0
+            precipitation_probability: 20.0
+            precipitation_amount_mm: 0.5
+            wind_speed_kmh: 15.0
+            conditions: "partly_cloudy"
     properties:
       forecast_id:
         type: string

--- a/tests/unit/test_generate_schema_path_resolution_unit.py
+++ b/tests/unit/test_generate_schema_path_resolution_unit.py
@@ -1,0 +1,158 @@
+"""Unit tests for schema path resolution in generate_from_source_config()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from teds_core.errors import TedsError
+from teds_core.generate import generate_from_source_config
+from tests.utils import load_yaml_file
+
+
+class TestSchemaPathResolution:
+    """Test that schema paths are always resolved relative to base_dir (CWD), not target directory."""
+
+    def test_schema_path_resolved_relative_to_cwd_not_target_dir(self, tmp_path: Path):
+        """Test that schema paths are resolved relative to CWD, even with explicit targets in subdirectories."""
+        # Setup directory structure:
+        # tmp_path/
+        #   ├── schema.yaml (schema file)
+        #   └── subdir/
+        #       └── output.yaml (target file)
+
+        schema_file = tmp_path / "schema.yaml"
+        schema_file.write_text(
+            """
+$defs:
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+""",
+            encoding="utf-8",
+        )
+
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+
+        # Configuration with explicit target in subdirectory
+        config = {
+            "schema.yaml": {"paths": ["$['$defs'].*"], "target": "subdir/output.yaml"}
+        }
+
+        # Generate from config - should resolve schema.yaml relative to tmp_path (CWD)
+        # This should succeed because schema.yaml exists at tmp_path/schema.yaml
+        generate_from_source_config(config, tmp_path)
+
+        # Verify output file was created in the correct target location
+        output_file = subdir / "output.yaml"
+        assert output_file.exists()
+
+        # Verify the reference in the test file is correct (relative to test file location)
+        doc = load_yaml_file(output_file)
+        assert "tests" in doc
+        test_keys = list(doc["tests"].keys())
+        assert len(test_keys) > 0
+
+        # The reference should be relative to the test file location (../schema.yaml)
+        expected_ref = "../schema.yaml#/$defs/User"
+        assert (
+            expected_ref in test_keys
+        ), f"Expected reference '{expected_ref}' not found in test keys: {test_keys}"
+
+    def test_schema_path_resolution_fails_when_schema_not_found_relative_to_cwd(
+        self, tmp_path: Path
+    ):
+        """Test that schema path resolution fails when schema doesn't exist relative to CWD."""
+        # Setup directory structure that would pass with old logic but fail with new logic:
+        # tmp_path/
+        #   └── subdir/
+        #       ├── schema.yaml (schema file - old logic would find this)
+        #       └── output.yaml (target file)
+        #
+        # Note: No schema.yaml at tmp_path/schema.yaml (new logic should fail)
+
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+
+        # Create schema file in subdir (old logic would find this, new logic shouldn't)
+        schema_file = subdir / "schema.yaml"
+        schema_file.write_text(
+            """
+$defs:
+  User:
+    type: object
+    properties:
+      name:
+        type: string
+""",
+            encoding="utf-8",
+        )
+
+        # Configuration with target in same subdirectory as schema
+        config = {
+            "schema.yaml": {  # This references schema.yaml but it doesn't exist at CWD level
+                "paths": ["$['$defs'].*"],
+                "target": "subdir/output.yaml",
+            }
+        }
+
+        # This should fail because schema.yaml doesn't exist at tmp_path/schema.yaml
+        # With the new logic, schema paths are always resolved relative to CWD
+        with pytest.raises(TedsError, match="Failed to load schema"):
+            generate_from_source_config(config, tmp_path)
+
+    def test_schema_path_with_relative_reference_in_config(self, tmp_path: Path):
+        """Test schema path resolution when config contains relative paths."""
+        # Setup directory structure:
+        # tmp_path/
+        #   ├── models/
+        #   │   └── user.yaml (schema file)
+        #   └── tests/
+        #       └── user_tests.yaml (target file)
+
+        models_dir = tmp_path / "models"
+        models_dir.mkdir()
+        schema_file = models_dir / "user.yaml"
+        schema_file.write_text(
+            """
+$defs:
+  User:
+    type: object
+    properties:
+      id:
+        type: string
+""",
+            encoding="utf-8",
+        )
+
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+
+        # Configuration with relative schema path and target
+        config = {
+            "models/user.yaml": {
+                "paths": ["$['$defs'].*"],
+                "target": "tests/user_tests.yaml",
+            }
+        }
+
+        # Generate from config - should resolve models/user.yaml relative to tmp_path (CWD)
+        generate_from_source_config(config, tmp_path)
+
+        # Verify output file was created
+        output_file = tests_dir / "user_tests.yaml"
+        assert output_file.exists()
+
+        # Verify the reference in the test file
+        doc = load_yaml_file(output_file)
+        test_keys = list(doc["tests"].keys())
+
+        # The reference should be relative to the test file location (../models/user.yaml)
+        expected_ref = "../models/user.yaml#/$defs/User"
+        assert (
+            expected_ref in test_keys
+        ), f"Expected reference '{expected_ref}' not found in test keys: {test_keys}"


### PR DESCRIPTION
## Summary

Fixes inconsistent schema path resolution where paths were resolved relative to target directory instead of current working directory.

- **Problem**: Template paths like `agriculture/agriculture.yaml#/$defs=teds/{base}.yaml` would incorrectly look for schema at `teds/agriculture/agriculture.yaml` instead of `agriculture/agriculture.yaml`
- **Solution**: Schema paths are now always resolved relative to CWD, ensuring consistent behavior regardless of target specification
- **Impact**: Fixes template path resolution for JSON-Pointer syntax with explicit targets

## Changes

- Fix schema path resolution logic in `generate_from_source_config()`
- Add comprehensive BDD tests for template path resolution scenarios  
- Add unit tests to validate schema path resolution logic and prevent regression
- Update existing BDD tests that expected incorrect behavior