### PR TITLE
fix: correctly handle RFC 6901 empty-key property pointer

### DIFF
--- a/teds_core/generate.py
+++ b/teds_core/generate.py
@@ -281,15 +281,19 @@ def parse_generate_config(config_str: str) -> dict[str, dict[str, Any]] | str:
                 raise TedsError(f"Missing schema file path: {ref_part}")
 
             # Convert JSON Pointer to JSON-Path with mandatory wildcard for children
-            fragment = fragment.lstrip("/")
-            if fragment:
-                # Convert /path/to/property to $["path"]["to"]["property"].*
-                parts = fragment.split("/")
+            # RFC 6901: "" = root, "/" = empty-key property
+            if fragment == "":
+                # Empty fragment: root children
+                jsonpath = "$.*"
+            elif fragment == "/":
+                # Single slash: children of empty-key property
+                jsonpath = '$[""].*'
+            else:
+                # Regular path: strip leading / and convert
+                fragment_stripped = fragment.lstrip("/")
+                parts = fragment_stripped.split("/")
                 quoted_parts = [f'["{part}"]' for part in parts]
                 jsonpath = "$" + "".join(quoted_parts) + ".*"
-            else:
-                # Root reference becomes $.*
-                jsonpath = "$.*"
 
             # Expand template variables in target if present
             expanded_target = None

--- a/tests/bdd/features/generate.feature
+++ b/tests/bdd/features/generate.feature
@@ -353,6 +353,66 @@ Feature: Generate Command Tests
       - "root.yaml#/properties/name"
       """
 
+  Scenario: Root pointer (RFC 6901) - empty fragment references root children
+    Given I have a schema file "empty_key.yaml" with content:
+      """yaml
+      foo:
+        type: string
+      "":
+        type: number
+        const: 0
+      """
+    When I run the CLI command: `./teds.py generate empty_key.yaml#`
+    Then a test file "empty_key.tests.yaml" should be created with content:
+      """yaml
+      version: "1.0.0"
+      tests:
+        empty_key.yaml#/foo:
+          valid: null
+          invalid: null
+        empty_key.yaml#/:
+          valid: null
+          invalid: null
+      """
+
+  Scenario: Empty-key property pointer (RFC 6901) - "/" references empty-key property children
+    Given I have a schema file "empty_key.yaml" with content:
+      """yaml
+      "":
+        foo:
+          type: number
+          const: 0
+      """
+    When I run the CLI command: `./teds.py generate empty_key.yaml#/`
+    Then a test file "empty_key.tests.yaml" should be created with content:
+      """yaml
+      version: "1.0.0"
+      tests:
+        empty_key.yaml#//foo:
+          valid: null
+          invalid: null
+      """
+
+  Scenario: Trailing slash references nested empty-key property (RFC 6901)
+    Given I have a schema file "nested_empty.yaml" with content:
+      """yaml
+      abc:
+        "":
+          xyz:
+            type: string
+        def:
+          type: number
+      """
+    When I run the CLI command: `./teds.py generate nested_empty.yaml#/abc/`
+    Then a test file "nested_empty.tests.yaml" should be created with content:
+      """yaml
+      version: "1.0.0"
+      tests:
+        nested_empty.yaml#/abc//xyz:
+          valid: null
+          invalid: null
+      """
+
   Scenario: Relative path with JSON Pointer
     Given I have a subdirectory "models"
     And I have a schema file "models/user.yaml" with content:

--- a/tests/unit/test_generate_parser_unit.py
+++ b/tests/unit/test_generate_parser_unit.py
@@ -49,11 +49,27 @@ class TestGenerateConfigurationParser:
         assert result == expected
 
     def test_parse_json_pointer_root_reference(self):
-        """Test JSON Pointer root reference normalization."""
+        """Test JSON Pointer root reference normalization (RFC 6901: empty fragment)."""
+        from teds_core.generate import parse_generate_config
+
+        result = parse_generate_config("schema.yaml#")
+        expected = {"schema.yaml": {"paths": ["$.*"], "target": None}}
+        assert result == expected
+
+    def test_parse_json_pointer_empty_key_property(self):
+        """Test JSON Pointer empty-key property reference (RFC 6901: single slash)."""
         from teds_core.generate import parse_generate_config
 
         result = parse_generate_config("schema.yaml#/")
-        expected = {"schema.yaml": {"paths": ["$.*"], "target": None}}
+        expected = {"schema.yaml": {"paths": ['$[""].*'], "target": None}}
+        assert result == expected
+
+    def test_parse_json_pointer_trailing_slash(self):
+        """Test JSON Pointer with trailing slash references nested empty-key property (RFC 6901)."""
+        from teds_core.generate import parse_generate_config
+
+        result = parse_generate_config("schema.yaml#/abc/")
+        expected = {"schema.yaml": {"paths": ['$["abc"][""].*'], "target": None}}
         assert result == expected
 
     def test_parse_json_pointer_nested_path(self):


### PR DESCRIPTION
## Summary

Fix handling of RFC 6901 JSON Pointer distinction between empty fragment and single slash for referencing root vs empty-key properties.

## Problem

RFC 6901 defines:
- Empty fragment → references root document
- Single slash → references property with empty key

Previous implementation incorrectly used lstrip which collapsed both cases into the same behavior.

## Changes

Implementation:
- Explicit handling for empty fragment → root children
- Explicit handling for single slash → empty-key property children  
- Regular paths continue to use lstrip as before

Tests:
- 3 new BDD scenarios for RFC 6901 cases
- 3 new unit tests
- 1 existing unit test corrected

## Test Results

- 174 unit tests passing
- 60 BDD tests passing